### PR TITLE
Support manual disconnection of onDomAlive observer

### DIFF
--- a/demo/app.vue
+++ b/demo/app.vue
@@ -46,6 +46,7 @@ const componentInfo = reactive<TargetResults>({
     target6: null,
 })
 provide('componentInfo', componentInfo)
+provide('isRunning', isRunning)
 
 
 function runInjector() {
@@ -152,7 +153,7 @@ onUnmounted(() => {
                 <ListenerTarget title="target 5" index=5 listenerAt="#target-5-btn"
                     desc="Pure event listening, no need to inject components" targetLabel="listener injection point" />
                 <ReInjectTarget title="target 6" index="6" componentAt="#target-6" desc="re-inject mechanism"
-                    targetLabel="re-injection point" :disappearTime="1500" :appearTime="1500" />
+                    targetLabel="re-injection point" :disappearTime="1500" :appearTime="1500" :isAlive="true" />
             </div>
             <LogPanel />
         </div>

--- a/demo/targets/ReInjectTarget.vue
+++ b/demo/targets/ReInjectTarget.vue
@@ -10,7 +10,7 @@ const props = defineProps<{
     targetLabel: string
     disappearTime: number
     appearTime: number
-    isStop?: boolean
+    isAlive: boolean
 }>();
 let timer: ReturnType<typeof setTimeout> | null = null;
 const isShowDelay = ref(true);
@@ -25,21 +25,17 @@ type TargetResults = {
 
 type Phase = 'idle-visible' | 'pending-hide' | 'idle-hidden' | 'pending-show';
 const phase = ref<Phase>('idle-visible');
+const aliveActive = ref(props.isAlive); // tracks whether alive observer is active
 
 const disappearDisabled = computed(() => phase.value !== 'idle-visible');
 const appearDisabled = computed(() => phase.value !== 'idle-hidden');
 const targetResults = (inject<TargetResults>('componentInfo') as TargetResults);
-console.log('targetResults', targetResults)
-
-
-
 
 const disappearTarget = () => {
     if (disappearDisabled.value) return;
     phase.value = 'pending-hide';
     timer = setTimeout(() => {
         isShowDelay.value = false;
-        targetResults.injectorInstance.stopAlive(targetResults.target6.id);
         phase.value = 'idle-hidden';
     }, props.disappearTime);
 }
@@ -51,6 +47,16 @@ const appearTarget = () => {
         isShowDelay.value = true;
         phase.value = 'idle-visible';
     }, props.appearTime);
+}
+
+const handleKeepAlive = () => {
+    targetResults.target6.keepAlive();
+    aliveActive.value = true;
+}
+
+const handleStopAlive = () => {
+    targetResults.target6.stopAlive();
+    aliveActive.value = false;
 }
 
 
@@ -65,6 +71,14 @@ const appearTarget = () => {
                 <button class="btn btn-secondary" @click="appearTarget" :disabled="appearDisabled">
                     Appears in {{ appearTime / 1000 }}s
                 </button>
+                <template v-if="props.isAlive">
+                    <button class="btn btn-alive" @click="handleKeepAlive" :disabled="aliveActive">
+                        keepAlive
+                    </button>
+                    <button class="btn btn-alive-stop" @click="handleStopAlive" :disabled="!aliveActive">
+                        stopAlive
+                    </button>
+                </template>
             </div>
         </template>
     </Target>
@@ -98,5 +112,17 @@ const appearTarget = () => {
     background: #1e3a5f;
     color: #7dd3fc;
     border: 1px solid #2563eb44;
+}
+
+.btn-alive {
+    background: #14532d;
+    color: #86efac;
+    border: 1px solid #22c55e44;
+}
+
+.btn-alive-stop {
+    background: #7f1d1d;
+    color: #fca5a5;
+    border: 1px solid #ef444444;
 }
 </style>

--- a/demo/targets/Target.vue
+++ b/demo/targets/Target.vue
@@ -1,4 +1,7 @@
 <script setup lang="ts">
+import { inject, ref, type Ref } from 'vue';
+
+const isRunning = inject<Ref<boolean>>('isRunning', ref(false));
 
 const props = withDefaults(defineProps<{
     title: string
@@ -37,14 +40,18 @@ const activitySignal = defineModel<boolean>('activitySignal', { default: undefin
             </p>
             <p class="card-desc">Desc: <code>{{ desc }}</code></p>
         </div>
-        <slot name="conditionalBtn"></slot>
+        <div :class="['slot-actions', { disabled: !isRunning }]">
+            <slot name="conditionalBtn"></slot>
+        </div>
         <template v-if="isShowTargetBox">
             <div class="target-box" v-if="isShowDelay" :id="`target-${index}`">
                 <span class="target-label">{{ targetLabel }}</span>
             </div>
             <div v-else class="target-placeholder">[ The target has not yet appeared ]</div>
         </template>
-        <slot name="secondaryBtn"></slot>
+        <div :class="['slot-actions', { disabled: !isRunning }]">
+            <slot name="secondaryBtn"></slot>
+        </div>
     </section>
 </template>
 <style scoped>
@@ -131,6 +138,12 @@ const activitySignal = defineModel<boolean>('activitySignal', { default: undefin
 .tag-off {
     color: #f87171;
     font-weight: 600;
+}
+
+.slot-actions.disabled {
+    pointer-events: none;
+    opacity: .4;
+    user-select: none;
 }
 
 .click-log {

--- a/src/core/DomWatcher.ts
+++ b/src/core/DomWatcher.ts
@@ -31,7 +31,7 @@ export class DOMWatcher {
 			// In once mode, disconnect immediately after finding the element
 			if (options?.once) {
 				disconnect();
-				console.log('[DOMWatcher] Element found, observer disconnected (once mode).');
+				console.log(`[vue-injector] Element "${selector}" found, observer disconnected`);
 			}
 		};
 
@@ -50,7 +50,7 @@ export class DOMWatcher {
 			setTimeout(() => {
 				disconnect();
 				console.warn(
-					`[DOMWatcher Warning] "${selector}" not found within ${options.timeout}ms.`
+					`[vue-injector] Element "${selector}" not found within ${options.timeout}ms, observer disconnected`
 				);
 			}, options.timeout);
 		}
@@ -71,8 +71,8 @@ export class DOMWatcher {
 		this.setupRemovalObserver(
 			target,
 			() => {
-				if (!isObserver) return;
 				onRemove();
+				if (!isObserver) return;
 				this.onDomReady(
 					selector,
 					(newTarget) => {
@@ -87,7 +87,7 @@ export class DOMWatcher {
 		);
 		return () => {
 			isObserver = false;
-			console.log(`[DOMWatcher] onDomAlive observer for "${selector}" has been manually disconnected.`);
+			console.log(`[vue-injector] Alive observer for "${selector}" stopped`);
 		};
 	}
 
@@ -146,14 +146,14 @@ export class DOMWatcher {
 		const isDocument: boolean = baseTarget instanceof HTMLBodyElement;
 		if (baseTarget === null) {
 			console.error(
-				`[DOMWatcher Error] Failed to set up removal observer: unable to find a valid observation target in the provided root.`
+				`[vue-injector] Failed to set up removal observer: no valid observation target found`
 			);
 			return null;
 		}
 
 		if (!isDocument && !baseTarget.isConnected) {
 			console.error(
-				'[DOMWatcher Error] Failed to set up removal observer: the observation target is not connected to the DOM.'
+				'[vue-injector] Failed to set up removal observer: observation target is detached from DOM'
 			);
 			return null;
 		}
@@ -184,7 +184,7 @@ export class DOMWatcher {
 		});
 
 		console.log(
-			`[DOMWatcher] Starting to observe target element for removal, at `,
+			`[vue-injector] Removal observer started`,
 			observerNode
 		);
 		return observer;

--- a/src/core/Injector.ts
+++ b/src/core/Injector.ts
@@ -48,17 +48,17 @@ export class Injector {
 
 	public run(): void {
 		if (this.taskContext.getRunningFlag()) {
-			console.warn('[Injector Warning] Injector is already running, do not call run() again');
+			console.warn('[vue-injector] Injector is already running, duplicate run() call ignored');
 			return;
 		}
 		if (this.taskContext.injectPoints.length === 0) {
 			throw new Error(
-				'[Injector Error] No tasks found to inject, please ensure tasks are registered'
+				'[vue-injector] No registered tasks found, call register() before run()'
 			);
 		}
 		if (!this.taskContext.getPinia()) {
 			throw new Error(
-				'[Injector Error] Pinia instance not found, please initialize Pinia before use'
+				'[vue-injector] Pinia instance not set, call setPinia() before run()'
 			);
 		}
 		this.taskContext.setRunningFlag(true);
@@ -83,7 +83,7 @@ export class Injector {
 
 		if (this.taskContext.has(id)) {
 			throw new Error(
-				`[Injector Error] Listener ${id} is already registered, do not register again`
+				`[vue-injector] Listener "${id}" is already registered`
 			);
 		}
 
@@ -101,7 +101,7 @@ export class Injector {
 		}
 		this.taskContext.set(id, context);
 		this.taskContext.injectPoints.push({ id: id, injectAt: listenAt });
-		console.log(`[Injector] Task ${id} registered successfully.`);
+		console.log(`[vue-injector] Listener "${id}" registered`);
 		return id;
 	}
 
@@ -114,9 +114,13 @@ export class Injector {
 		if (this.taskContext.has(taskId)) {
 			// Component already registered, return directly
 			console.warn(
-				`[Injector Warning] Component ${taskId} is already registered, do not register again`
+				`[vue-injector] Task "${taskId}" is already registered, skipping`
 			);
-			return { id: taskId };
+			return {
+				id: taskId,
+				keepAlive: () => this.keepAlive(taskId),
+				stopAlive: () => this.stopAlive(taskId)
+			};
 		}
 		// Use unified InjectionContext to store all information
 		const context: InjectionContext = {
@@ -125,8 +129,10 @@ export class Injector {
 			componentInjectAt: injectAt,
 			component: this.markRawComponent(component),
 			withEvent: false,
+
 			alive: option?.alive ?? this.injectConfig.alive,
-			scope: option?.scope ?? this.injectConfig.scope
+			scope: option?.scope ?? this.injectConfig.scope,
+			isObserver: false
 		};
 
 		if (option?.on) {
@@ -148,31 +154,111 @@ export class Injector {
 			id: taskId,
 			injectAt: injectAt
 		});
-		console.log(`[Injector] Task: ${taskId} registered successfully`);
+		console.log(`[vue-injector] Task "${taskId}" registered`);
 		return {
 			id: taskId,
+			keepAlive: () => this.keepAlive(taskId),
 			stopAlive: () => this.stopAlive(taskId)
 		};
+	}
+
+	public keepAlive(id: string): void {
+		const context = this.taskContext.get(id);
+		if (!context) {
+			console.error(`[vue-injector] Task "${id}" not found`);
+			return;
+		}
+
+		// keepAlive only applies to component tasks
+		if (!context.component || !context.componentInjectAt) {
+			console.warn(
+				`[vue-injector] keepAlive is not applicable to non-component task "${id}"`
+			);
+			return;
+		}
+
+		// Already alive with an active observer, skip
+		if (context.alive && context.isObserver) {
+			console.warn(
+				`[vue-injector] Task "${id}" already has an active alive observer`
+			);
+			return;
+		}
+
+		context.alive = true;
+
+		// Case 1: Component is already mounted and connected — set up the alive observer directly
+		if (context.app && context.appRoot?.isConnected) {
+			const matchedElement = context.appRoot.parentElement;
+			if (!matchedElement) {
+				console.warn(
+					`[vue-injector] Task "${id}": host element not found, unable to activate alive observer`
+				);
+				return;
+			}
+
+			const currentDocument = matchedElement.ownerDocument || document;
+			const injectAt = context.componentInjectAt;
+
+			nextTick().then(() => {
+				const stopHandler = this.domWatcher.onDomAlive(
+					matchedElement,
+					injectAt,
+					() => {
+						this.taskContext.resetState(id);
+					},
+					(el): void => this.handleInjectionReady(el, id),
+					context.scope === 'global' ? currentDocument : matchedElement
+				);
+				context.stopAlive = stopHandler;
+				context.isObserver = true;
+				console.log(`[vue-injector] Task "${id}" alive observer activated`);
+			});
+			return;
+		}
+
+		// Case 2: Component is not mounted (e.g., removed from DOM after stopAlive was called)
+		// Re-trigger onDomReady to wait for the target element and re-inject
+		if (!context.app) {
+			let cancelled = false;
+			this.domWatcher.onDomReady(
+				context.componentInjectAt,
+				(el): void => {
+					if (cancelled) return;
+					this.handleInjectionReady(el, id);
+				},
+				document,
+				{ once: true, timeout: this.injectConfig.timeout }
+			);
+			context.stopAlive = () => {
+				cancelled = true;
+			};
+			context.isObserver = true;
+			console.log(
+				`[vue-injector] Task "${id}" awaiting target element for re-injection`
+			);
+		}
 	}
 
 	public stopAlive(id: string): void {
 		const context = this.taskContext.get(id);
 
 		if (!context) {
-			console.error(`[Injector Error] Task ${id} not found.`);
+			console.error(`[vue-injector] Task "${id}" not found`);
 			return;
 		}
 
 		// status check: if not set alive mode or no stopAlive handler, warn and exit
 		if (!context.alive || !context.stopAlive) {
 			console.warn(
-				`[Injector Warning] Task ${id}: No active "alive" handler to stop. (Status: alive=${!!context.alive})`
+				`[vue-injector] Task "${id}" has no active alive observer to stop`
 			);
 			return;
 		}
 
 		context.stopAlive();
 		context.alive = false;
+		context.isObserver = false;
 		context.stopAlive = undefined;
 	}
 
@@ -192,7 +278,7 @@ export class Injector {
 		// Bind a reactive signal to control automatic listener attach/detach for this task
 		const context: InjectionContext | undefined = this.taskContext.get(id);
 		if (!context) {
-			console.error(`[Injector Error] Context not found for ${id}`);
+			console.error(`[vue-injector] Task "${id}" not found, unable to bind activity signal`);
 			return;
 		}
 
@@ -214,7 +300,7 @@ export class Injector {
 		const context: InjectionContext | undefined = this.taskContext.get(id);
 		if (!context) {
 			console.error(
-				`[Injector Error] Context not found for Task ${id}, unable to manage event state`
+				`[vue-injector] Task "${id}" not found, unable to manage listener state`
 			);
 			return;
 		}
@@ -222,7 +308,7 @@ export class Injector {
 		// Check if event binding is configured
 		if (!context.withEvent || !context.listenAt || !context.event || !context.callback) {
 			console.warn(
-				`[Injector Warning] Task ${id} has no event binding configured, unable to manage event state`
+				`[vue-injector] Task "${id}" has no event binding configured`
 			);
 			return;
 		}
@@ -245,7 +331,7 @@ export class Injector {
 					context.controller = newController;
 				} else {
 					console.error(
-						`[Injector Error] Failed to bind event ${context.event}, unable to rebind`
+						`[vue-injector] Failed to attach event "${context.event}" for task "${id}"`
 					);
 				}
 				break;
@@ -257,13 +343,13 @@ export class Injector {
 
 				context.controller.abort(); // Abort event listener
 				context.controller = undefined;
-				console.log(`[Injector] Event ${context.event} on Task ${id} has been unbound`);
+				console.log(`[vue-injector] Event "${context.event}" detached from task "${id}"`);
 				break;
 			}
 
 			default: {
 				console.warn(
-					`[Injector Warning] Unsupported event action ${event.type}, please check the event action`
+					`[vue-injector] Unknown action type "${event.type}" for task "${id}"`
 				);
 			}
 		}
@@ -273,7 +359,7 @@ export class Injector {
 		const context = this.taskContext.get(id);
 		if (!context) {
 			console.error(
-				`[Injector Error] Context not found for Task ${id}, unable to inject component`
+				`[vue-injector] Task "${id}" not found, unable to proceed with injection`
 			);
 			return;
 		}
@@ -316,7 +402,7 @@ export class Injector {
 				signal: controller.signal
 			});
 			console.log(
-				`[Injector] Event binding successful, id: ${id}, event: ${event}, listenAt: ${listenAt}`
+				`[vue-injector] Event "${event}" attached at "${listenAt}" (task: ${id})`
 			);
 			return controller;
 		}
@@ -330,7 +416,7 @@ export class Injector {
 					signal: proxyController.signal
 				});
 				console.log(
-					`[Injector] Event binding successful, id: ${id}, event: ${event}, listenAt: ${listenAt}`
+					`[vue-injector] Event "${event}" attached at "${listenAt}" (task: ${id})`
 				);
 			},
 			document,
@@ -346,14 +432,14 @@ export class Injector {
 		const context: InjectionContext | undefined = this.taskContext.get(taskId);
 		if (!context || !context.componentInjectAt) {
 			console.error(
-				`[Injector Error] Context not found for component ${taskId}, unable to inject`
+				`[vue-injector] Task "${taskId}" context missing, injection aborted`
 			);
 			return false;
 		}
 
 		if (context?.app) {
 			console.warn(
-				`[Injector Warning] Component ${taskId} is already mounted, skipping duplicate injection`
+				`[vue-injector] Task "${taskId}" is already mounted, skipping`
 			);
 			return false;
 		}
@@ -363,7 +449,7 @@ export class Injector {
 
 		if (!context?.component || !context.taskId) {
 			console.error(
-				`[Injector Error] Component not found for injection point ${injectAt}, please ensure it is registered`
+				`[vue-injector] No component found for task "${taskId}", injection aborted`
 			);
 			return false;
 		}
@@ -379,7 +465,7 @@ export class Injector {
 			matchedElement.appendChild(appRoot); // matchedElement is the target host element
 		} else {
 			console.warn(
-				`[Injector Warning] Target element is not connected to the DOM, this task will be stopped injection`
+				`[vue-injector] Target element for task "${taskId}" is detached from DOM, injection skipped`
 			);
 			return false;
 		}
@@ -396,13 +482,10 @@ export class Injector {
 			context.appRoot = appRoot;
 
 			console.log(
-				'[Injector] Component injected successfully, name:',
-				context.componentName,
-				'injectAt:',
-				injectAt
+				`[vue-injector] Component "${context.componentName}" injected at "${injectAt}"`
 			);
 
-			if (context.alive) {
+			if (context.alive && !context.isObserver) {
 				// Injection re-injection mechanism
 				// if write 'global', the watcher will observer the document body element
 				// if write 'local', the watcher will observe the matchedElement, which is the component's host element
@@ -417,13 +500,14 @@ export class Injector {
 						context.scope === 'global' ? currentDocument : matchedElement
 					);
 					context.stopAlive = stopHandler;
-					console.log(`[Injector] DomAlive watcher set for taskId ${taskId}`);
+					context.isObserver = true;
+					console.log(`[vue-injector] Task "${taskId}" alive observer activated`);
 				});
 			}
 
 			return true;
 		} catch (error) {
-			console.error(`[Injector Error] Component mount failed:`, error);
+			console.error(`[vue-injector] Component mount failed for task "${taskId}":`, error);
 			appRoot.remove();
 			return false;
 		}

--- a/src/core/TaskContext.ts
+++ b/src/core/TaskContext.ts
@@ -49,7 +49,7 @@ export class TaskContext {
 	public setPinia(piniaInstance: Pinia): void {
 		if (this.pinia) {
 			console.warn(
-				'[Injector Warning] Pinia instance already exists, it will be overwritten'
+				'[vue-injector] Pinia instance already set, overwriting'
 			);
 		}
 		this.pinia = piniaInstance;
@@ -61,7 +61,7 @@ export class TaskContext {
 		const context: InjectionContext | undefined = this.contextMap.get(id);
 		if (!context) {
 			console.warn(
-				`[Injector Warning] Task ${id} not found, it may have been destroyed or was never registered`
+				`[vue-injector] Task "${id}" not found, may already be destroyed`
 			);
 			return;
 		}
@@ -114,7 +114,7 @@ export class TaskContext {
 		this.isRunning = false;
 		this.pinia = null;
 
-		console.log('[Injector] All injection instances have been destroyed');
+		console.log('[vue-injector] All tasks destroyed');
 	}
 
 	public releaseComponentInstance(id: string): void {
@@ -125,11 +125,11 @@ export class TaskContext {
 				context.app = undefined;
 				context.instance = undefined;
 			} catch (error) {
-				console.error(`[TaskContext Error] Failed to unmount component ${id}:`, error);
+				console.error(`[vue-injector] Failed to unmount component for task "${id}":`, error);
 			}
 		} else {
 			console.warn(
-				`[TaskContext Warning] Component instance ${id} not found, it may have been unmounted already`
+				`[vue-injector] Component for task "${id}" already unmounted`
 			);
 		}
 	}
@@ -138,13 +138,13 @@ export class TaskContext {
 		const context: InjectionContext | undefined = this.contextMap.get(id);
 		if (!context) {
 			console.warn(
-				`[TaskContext Warning] Context not found for ${id}, unable to remove mount root element`
+				`[vue-injector] Task "${id}" context not found, unable to remove root element`
 			);
 			return;
 		}
 		if (!context.appRoot) {
 			console.warn(
-				`[TaskContext Warning] Mount root element not found for ${id}, please check if the component mount point exists`
+				`[vue-injector] Root element for task "${id}" not found, may already be removed`
 			);
 			return;
 		}
@@ -153,7 +153,7 @@ export class TaskContext {
 			context.appRoot = undefined;
 		} catch (error) {
 			console.error(
-				`[TaskContext Error] Failed to remove component root element ${id}:`,
+				`[vue-injector] Failed to remove root element for task "${id}":`,
 				error
 			);
 		}
@@ -167,7 +167,7 @@ export class TaskContext {
 			try {
 				context.controller.abort();
 			} catch (error) {
-				console.error(`[TaskContext Error] Failed to abort event task ${id}:`, error);
+				console.error(`[vue-injector] Failed to abort listener for task "${id}":`, error);
 			}
 		}
 
@@ -188,7 +188,7 @@ export class TaskContext {
 				context.watcher = undefined;
 				context.watchSource = undefined;
 			} catch (error) {
-				console.error(`[TaskContext Error] Failed to stop watcher ${id}:`, error);
+				console.error(`[vue-injector] Failed to stop watcher for task "${id}":`, error);
 			}
 		}
 	}

--- a/src/type.ts
+++ b/src/type.ts
@@ -63,11 +63,13 @@ export type InjectionContext = {
 	watcher?: WatchHandle;
 	watchSource?: WatchSource<boolean>;
 
+	isObserver?: boolean;
 	alive?: boolean;
 	scope?: 'local' | 'global';
 	stopAlive?: () => void;
 };
 export type RegisterResult = {
 	id: string;
-	stopAlive?: () => void;
+	keepAlive: () => void;
+	stopAlive: () => void;
 };


### PR DESCRIPTION
This pull request introduces several improvements and new features to the demo and core logic of the injector system, focusing on enhanced reactivity, better demo controls, and improved logging and error messages. The main changes are the addition of a reactive `provide/inject` system for sharing component and injector state in the demo, the implementation of alive/keepAlive controls for injected components, and the unification and clarification of log and error messages throughout the core code.

**Enhancements to demo reactivity and controls:**

* Introduced a reactive `componentInfo` object and provided it (along with `isRunning`) at the root level in `app.vue`; this allows child components to access up-to-date injector and registration state via `inject`. (`demo/app.vue`, `demo/targets/ReInjectTarget.vue`) [[1]](diffhunk://#diff-a679671703580424e31801b64b6a142a9bf9b68ebbdb9fda2a1e64a9aa545749R30-R49) [[2]](diffhunk://#diff-a679671703580424e31801b64b6a142a9bf9b68ebbdb9fda2a1e64a9aa545749L75-R112) [[3]](diffhunk://#diff-f6aeb44f51e09eca432e874d4707813eb4255d1196d83b18bf067f2c55282d83R13-R32)
* Updated `ReInjectTarget.vue` to use the injected `componentInfo` and added `keepAlive`/`stopAlive` controls, enabling manual toggling of the alive observer for injected components. Also added new button styles for these controls. (`demo/targets/ReInjectTarget.vue`) [[1]](diffhunk://#diff-f6aeb44f51e09eca432e874d4707813eb4255d1196d83b18bf067f2c55282d83R52-R61) [[2]](diffhunk://#diff-f6aeb44f51e09eca432e874d4707813eb4255d1196d83b18bf067f2c55282d83R74-R81) [[3]](diffhunk://#diff-f6aeb44f51e09eca432e874d4707813eb4255d1196d83b18bf067f2c55282d83R116-R127)
* Enhanced `Target.vue` and its consumers to disable action slots when the injector is not running, improving the demo's UX. (`demo/targets/Target.vue`) [[1]](diffhunk://#diff-11f182d2deeb3b9f76f1d2e0fd765c34b88bbb628d1826fc16420c11f4c82e8eR2-R4) [[2]](diffhunk://#diff-11f182d2deeb3b9f76f1d2e0fd765c34b88bbb628d1826fc16420c11f4c82e8eR43-R54) [[3]](diffhunk://#diff-11f182d2deeb3b9f76f1d2e0fd765c34b88bbb628d1826fc16420c11f4c82e8eR143-R148)

**Core logic and logging improvements:**

* Standardized and clarified all log and error messages in `DOMWatcher` and `Injector` to use the `[vue-injector]` prefix, making logs more consistent and easier to trace. (`src/core/DomWatcher.ts`, `src/core/Injector.ts`) [[1]](diffhunk://#diff-7cc319ac9c860b831a08d2235bb847a12ee77818abb132e5dab3fa0cb324cd81L34-R34) [[2]](diffhunk://#diff-7cc319ac9c860b831a08d2235bb847a12ee77818abb132e5dab3fa0cb324cd81L52-R54) [[3]](diffhunk://#diff-7cc319ac9c860b831a08d2235bb847a12ee77818abb132e5dab3fa0cb324cd81L68-R90) [[4]](diffhunk://#diff-7cc319ac9c860b831a08d2235bb847a12ee77818abb132e5dab3fa0cb324cd81L154-R156) [[5]](diffhunk://#diff-7cc319ac9c860b831a08d2235bb847a12ee77818abb132e5dab3fa0cb324cd81L193-R187) [[6]](diffhunk://#diff-8d62ea05fc9023d67ee0017f9df451c79a16f0113111697c75c49deeec2e8083L50-R61) [[7]](diffhunk://#diff-8d62ea05fc9023d67ee0017f9df451c79a16f0113111697c75c49deeec2e8083L86-R86)
* Refactored the alive observer logic in `DOMWatcher` for better control and reliability, using a boolean flag instead of a stopped variable, and improved the observer's lifecycle management. (`src/core/DomWatcher.ts`)

**Type and interface updates:**

* Updated type imports and usage in `Injector.ts` to include `RegisterResult` and renamed `eventOptions` to `ComponentOptions` for clarity. (`src/core/Injector.ts`)

**Demo behavior and configuration tweaks:**

* Changed the default `alive` option for the injector in the demo to `false` to better demonstrate manual alive control. (`demo/app.vue`)
* Passed the new `isAlive` prop to `ReInjectTarget` in the demo for more explicit alive state management. (`demo/app.vue`, `demo/targets/ReInjectTarget.vue`) [[1]](diffhunk://#diff-a679671703580424e31801b64b6a142a9bf9b68ebbdb9fda2a1e64a9aa545749L122-R156) [[2]](diffhunk://#diff-f6aeb44f51e09eca432e874d4707813eb4255d1196d83b18bf067f2c55282d83R13-R32)

These changes collectively make the injector demo more interactive and maintainable, while also improving the clarity and reliability of the core injector logic.
