### PR TITLE
test/add Injector testing support 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ dist-ssr
 !.vscode/extensions.json
 .idea
 .vscode
+.zed
 .DS_Store
 *.suo
 *.ntvs*

--- a/src/__test__/Injector.test.ts
+++ b/src/__test__/Injector.test.ts
@@ -1,0 +1,1150 @@
+﻿/// <reference types="vitest/config" />
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { nextTick, ref, WatchHandle } from 'vue';
+import { DOMWatcher } from '../core/DomWatcher';
+import { Injector } from '../core/Injector';
+import type { TaskContext } from '../core/TaskContext';
+import { Action, type RegisterResult } from '../type';
+
+describe('Injector', () => {
+	let injector: Injector;
+	let taskContext: TaskContext;
+	beforeEach(() => {
+		injector = new Injector();
+		taskContext = injector.getTaskContext() as TaskContext;
+		document.body.innerHTML = '';
+		vi.spyOn(console, 'log').mockImplementation(() => { });
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		document.body.innerHTML = '';
+	});
+
+	describe('constructor', () => {
+		it('should create an instance of Injector', () => {
+			expect(injector).toBeInstanceOf(Injector);
+		});
+
+		it('should accept partial config without error', () => {
+			expect(() => new Injector({ timeout: 10000 })).not.toThrow();
+		});
+
+		it('should accept full config without error', () => {
+			expect(
+				() => new Injector({ alive: true, scope: 'global', timeout: 3000 })
+			).not.toThrow();
+		});
+
+		it('should apply custom timeout — warn appears earlier with shorter timeout', () => {
+			vi.useFakeTimers();
+			const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => { });
+
+			const fast = new Injector({ timeout: 100 });
+			fast.register('#nonexistent', { name: 'T' });
+			fast.run();
+
+			vi.advanceTimersByTime(200);
+			expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('not found within 100ms'));
+
+			vi.useRealTimers();
+		});
+
+		it('should apply custom timeout — default 5000ms does not warn before that', () => {
+			vi.useFakeTimers();
+			const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => { });
+
+			injector.register('#nonexistent', { name: 'T' });
+			injector.run();
+
+			vi.advanceTimersByTime(1000);
+			expect(warnSpy).not.toHaveBeenCalledWith(expect.stringContaining('not found within'));
+
+			vi.useRealTimers();
+		});
+	});
+
+	describe('register', () => {
+		it('should return RegisterResult with correct id format (name@selector)', () => {
+			const result: RegisterResult = injector.register('#app', {
+				name: 'MyComp'
+			});
+
+			expect(result.id).toBe('MyComp@#app');
+			expect(typeof result.keepAlive).toBe('function');
+			expect(typeof result.stopAlive).toBe('function');
+		});
+
+		it('should use __name when name is not present (SFC-style component)', () => {
+			const result = injector.register('#app', { __name: 'SfcComp' });
+			expect(result.id).toBe('SfcComp@#app');
+		});
+
+		it('should generate a unique id for anonymous plain-object component', () => {
+			const result = injector.register('#app', {});
+			expect(result.id).toMatch(/^component-[0-9a-f]+@#app$/);
+		});
+
+		it('should generate a unique id for anonymous function component', () => {
+			const comp = [() => { }][0];
+			const result = injector.register('#app', comp);
+			expect(result.id).toMatch(/^component-[0-9a-f]+@#app$/);
+		});
+
+		it('should reuse the same generated name for the same anonymous component ref', () => {
+			const comp = {};
+			const r1 = injector.register('#a', comp);
+			const r2 = injector.register('#b', comp);
+
+			const name1 = r1.id.split('@')[0];
+			const name2 = r2.id.split('@')[0];
+			expect(name1).toBe(name2);
+		});
+
+		it('should generate different names for different anonymous components', () => {
+			const r1 = injector.register('#a', {});
+			const r2 = injector.register('#b', {});
+
+			expect(r1.id.split('@')[0]).not.toBe(r2.id.split('@')[0]);
+		});
+
+		it('should warn and return same id on duplicate registration', () => {
+			const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => { });
+			const comp = { name: 'Dup' };
+
+			const first = injector.register('#app', comp);
+			const second = injector.register('#app', comp);
+
+			expect(second.id).toBe(first.id);
+			expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('already registered'));
+		});
+
+		it('should log on successful first registration', () => {
+			const logSpy = vi.mocked(console.log);
+			injector.register('#app', { name: 'Comp' });
+
+			expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('"Comp@#app" registered'));
+		});
+
+		it('should allow run() to succeed after registration (proves injectPoints populated)', () => {
+			injector.register('#app', { name: 'X' });
+			expect(() => injector.run()).not.toThrow();
+		});
+
+		it('duplicate registration should not cause run() to observe twice for the same id', () => {
+			vi.useFakeTimers();
+			vi.spyOn(console, 'warn').mockImplementation(() => { });
+
+			injector.register('#target', { name: 'D' });
+			injector.register('#target', { name: 'D' }); // duplicate
+
+			const el = document.createElement('div');
+			el.id = 'target';
+			document.body.appendChild(el);
+
+			injector.run();
+			vi.useRealTimers();
+
+			const logCalls = vi
+				.mocked(console.log)
+				.mock.calls.map((c) => c[0] as string)
+				.filter((msg) => msg.includes('injected'));
+			expect(logCalls.length).toBeLessThanOrEqual(1);
+		});
+
+		it('should allow registering multiple different components', () => {
+			const r1 = injector.register('#a', { name: 'A' });
+			const r2 = injector.register('#b', { name: 'B' });
+
+			expect(r1.id).toBe('A@#a');
+			expect(r2.id).toBe('B@#b');
+		});
+
+		it('should allow same component at different selectors', () => {
+			const comp = { name: 'Shared' };
+			const r1 = injector.register('#a', comp);
+			const r2 = injector.register('#b', comp);
+
+			expect(r1.id).toBe('Shared@#a');
+			expect(r2.id).toBe('Shared@#b');
+		});
+
+		it('destroyed() should not warn about missing task (proves context exists)', () => {
+			const { id } = injector.register('#app', { name: 'Del' });
+			const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => { });
+			injector.destroyed(id);
+
+			expect(warnSpy).not.toHaveBeenCalledWith(
+				expect.stringContaining('may already be destroyed')
+			);
+		});
+
+		it('returned keepAlive() should not throw for a component task', () => {
+			vi.spyOn(console, 'warn').mockImplementation(() => { });
+			const { keepAlive } = injector.register('#app', { name: 'KA' });
+			expect(() => keepAlive()).not.toThrow();
+		});
+
+		it('returned stopAlive() should warn when alive was not started', () => {
+			const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => { });
+			const { stopAlive } = injector.register('#app', { name: 'SA' });
+			stopAlive();
+			expect(warnSpy).toHaveBeenCalledWith(
+				expect.stringContaining('no active alive observer')
+			);
+		});
+
+		it('should enable event binding when on option is provided', () => {
+			const btn = document.createElement('button');
+			btn.id = 'btn';
+			document.body.appendChild(btn);
+
+			const cb = vi.fn();
+			const { id } = injector.register(
+				'#app',
+				{ name: 'Evt' },
+				{
+					on: { listenAt: '#btn', type: 'click', callback: cb }
+				}
+			);
+
+			injector.listenerActivity(id, { type: Action.OPEN });
+
+			btn.click();
+			expect(cb).toHaveBeenCalledOnce();
+		});
+
+		it('should not have event binding when no on option is provided', () => {
+			const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => { });
+			const { id } = injector.register('#app', { name: 'NoEvt' });
+
+			injector.listenerActivity(id, { type: Action.OPEN });
+
+			expect(warnSpy).toHaveBeenCalledWith(
+				expect.stringContaining('no event binding configured')
+			);
+		});
+	});
+	describe('registerListener', () => {
+		it('should register a listener correctly', () => {
+			const btn = document.createElement('button');
+			btn.id = 'btn';
+			document.body.appendChild(btn);
+			const cb = vi.fn();
+			injector.registerListener('#btn', 'click', cb);
+			injector.run();
+			btn.click();
+			expect(cb).toHaveBeenCalledOnce();
+		});
+		it('should warn if registering a listener on an element that does not exist', () => {
+			vi.useFakeTimers();
+			const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => { });
+			injector.registerListener('#nonexistent', 'click', () => { });
+			injector.run();
+			vi.advanceTimersByTime(5005);
+			expect(warnSpy).toHaveBeenCalledWith(
+				expect.stringContaining('Element "#nonexistent" not found within')
+			);
+		});
+		it('should set up listener of context task that not component info correctly', () => {
+			injector.registerListener('#btn', 'click', () => { });
+			const task = taskContext.get('listener-#btn-click');
+			expect(task?.component).toBeUndefined();
+			expect(task?.componentInjectAt).toBeUndefined();
+			expect(task?.componentName).toBeUndefined();
+			expect(task?.listenAt).toBe('#btn');
+			expect(task?.event).toBe('click');
+			expect(task?.callback).toBeInstanceOf(Function);
+		});
+		it('should throw error if registering a the same listener', () => {
+			injector.registerListener('#btn', 'click', () => { });
+
+			expect(() => injector.registerListener('#btn', 'click', () => { })).toThrow(
+				'is already registered'
+			);
+		});
+		it('should set up activitySignal for the listener correctly', async () => {
+			const mockRef = ref<boolean>(false);
+			const mockRefCb = vi.fn().mockReturnValue(mockRef);
+			const btn = document.createElement('button');
+			btn.id = 'btn';
+			document.body.appendChild(btn);
+			const cb = vi.fn();
+			injector.registerListener('#btn', 'click', cb, mockRefCb);
+			injector.run();
+
+			expect(mockRefCb).toHaveBeenCalledOnce();
+
+			btn.click();
+			expect(cb).not.toHaveBeenCalled();
+
+			mockRef.value = true;
+			await nextTick();
+			btn.click();
+			expect(cb).toHaveBeenCalledOnce();
+		});
+	});
+	describe('run', () => {
+		it('should call run() correctly without error', () => {
+			injector.register('#app', { name: 'RunTest' });
+			expect(() => injector.run()).not.toThrow();
+		});
+		it('should call run() will throw error if have not task in injector', () => {
+			expect(() => injector.run()).toThrow('No registered tasks found');
+		});
+		it('should warn if run() is called multiple times', () => {
+			const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => { });
+			injector.register('#app', { name: 'RunMulti' });
+			injector.run();
+			injector.run();
+			expect(warnSpy).toHaveBeenCalledWith(
+				expect.stringContaining('Injector is already running')
+			);
+		});
+
+		it('should set runningFlag to true after run()', () => {
+			injector.register('#app', { name: 'FlagCheck' });
+			injector.run();
+			expect(taskContext.getRunningFlag()).toBe(true);
+		});
+
+		it('should call domWatcher.onDomReady once for a single injectPoint with correct args', () => {
+			const onDomReadySpy = vi
+				.spyOn(DOMWatcher.prototype, 'onDomReady')
+				.mockReturnValue(() => { });
+
+			injector.register('#root', { name: 'Single' });
+			injector.run();
+
+			expect(onDomReadySpy).toHaveBeenCalledOnce();
+			expect(onDomReadySpy).toHaveBeenCalledWith('#root', expect.any(Function), document, {
+				once: true,
+				timeout: 5000
+			});
+		});
+
+		it('should call domWatcher.onDomReady once per injectPoint for multiple registrations', () => {
+			const onDomReadySpy = vi
+				.spyOn(DOMWatcher.prototype, 'onDomReady')
+				.mockReturnValue(() => { });
+
+			injector.register('#header', { name: 'CompA' });
+			injector.register('#footer', { name: 'CompB' });
+			injector.register('#sidebar', { name: 'CompC' });
+			injector.run();
+
+			expect(onDomReadySpy).toHaveBeenCalledTimes(3);
+			expect(onDomReadySpy).toHaveBeenNthCalledWith(
+				1,
+				'#header',
+				expect.any(Function),
+				document,
+				{ once: true, timeout: 5000 }
+			);
+			expect(onDomReadySpy).toHaveBeenNthCalledWith(
+				2,
+				'#footer',
+				expect.any(Function),
+				document,
+				{ once: true, timeout: 5000 }
+			);
+			expect(onDomReadySpy).toHaveBeenNthCalledWith(
+				3,
+				'#sidebar',
+				expect.any(Function),
+				document,
+				{ once: true, timeout: 5000 }
+			);
+		});
+
+		it('should pass the custom timeout from InjectionConfig to onDomReady', () => {
+			const onDomReadySpy = vi
+				.spyOn(DOMWatcher.prototype, 'onDomReady')
+				.mockReturnValue(() => { });
+
+			const customInjector = new Injector({ timeout: 8000 });
+			customInjector.register('#app', { name: 'TimeoutComp' });
+			customInjector.run();
+
+			expect(onDomReadySpy).toHaveBeenCalledOnce();
+			expect(onDomReadySpy).toHaveBeenCalledWith('#app', expect.any(Function), document, {
+				once: true,
+				timeout: 8000
+			});
+		});
+
+		it('should always pass once: true to onDomReady regardless of injectConfig', () => {
+			const onDomReadySpy = vi
+				.spyOn(DOMWatcher.prototype, 'onDomReady')
+				.mockReturnValue(() => { });
+
+			injector.register('#target', { name: 'OnceCheck' });
+			injector.run();
+
+			const callArgs = onDomReadySpy.mock.calls[0];
+			const options = callArgs[3] as { once: boolean; timeout?: number };
+			expect(options.once).toBe(true);
+		});
+
+		it('should pass the injectAt selector of each injectPoint as the first arg to onDomReady', () => {
+			const onDomReadySpy = vi
+				.spyOn(DOMWatcher.prototype, 'onDomReady')
+				.mockReturnValue(() => { });
+
+			const selectors = ['#one', '.two', '[data-three]'];
+			for (const sel of selectors) {
+				injector.register(sel, { name: `Comp-${sel}` });
+			}
+			injector.run();
+
+			const calledSelectors = onDomReadySpy.mock.calls.map((c) => c[0]);
+			expect(calledSelectors).toEqual(selectors);
+		});
+
+		it('should not call domWatcher.onDomReady when run() is called a second time', () => {
+			const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => { });
+			const onDomReadySpy = vi
+				.spyOn(DOMWatcher.prototype, 'onDomReady')
+				.mockReturnValue(() => { });
+
+			injector.register('#app', { name: 'NoDupRun' });
+			injector.run();
+			injector.run(); // second call — should be ignored
+
+			expect(onDomReadySpy).toHaveBeenCalledOnce();
+			expect(warnSpy).toHaveBeenCalledWith(
+				expect.stringContaining('Injector is already running')
+			);
+		});
+	});
+
+	describe('handleInjectionReady (indirect via run)', () => {
+		it('should mount component into DOM when target element is ready', () => {
+			const host = document.createElement('div');
+			host.id = 'inject-host';
+			document.body.appendChild(host);
+
+			const { id } = injector.register('#inject-host', { name: 'ReadyMount' });
+			injector.run();
+
+			const context = taskContext.get(id);
+			expect(context?.appRoot).toBeInstanceOf(HTMLElement);
+			expect(context?.appRoot?.parentElement).toBe(host);
+		});
+
+		it('should route to bindActivitySignal when activitySignal is provided', () => {
+			const host = document.createElement('div');
+			host.id = 'ready-with-signal';
+			document.body.appendChild(host);
+
+			const btn = document.createElement('button');
+			btn.id = 'btn-signal';
+			document.body.appendChild(btn);
+
+			const bindSignalSpy = vi
+				.spyOn(injector, 'bindActivitySignal')
+				.mockImplementation(() => { });
+			const listenerSpy = vi.spyOn(injector, 'listenerActivity');
+			const signal = ref(true);
+
+			injector.register(
+				'#ready-with-signal',
+				{ name: 'ReadyWithSignal' },
+				{
+					on: {
+						listenAt: '#btn-signal',
+						type: 'click',
+						callback: vi.fn(),
+						activitySignal: () => signal
+					}
+				}
+			);
+
+			injector.run();
+
+			expect(bindSignalSpy).toHaveBeenCalledOnce();
+			expect(listenerSpy).not.toHaveBeenCalledWith(
+				expect.any(String),
+				expect.objectContaining({ type: Action.OPEN })
+			);
+		});
+
+		it('should call listenerActivity OPEN directly when activitySignal is not provided', () => {
+			const host = document.createElement('div');
+			host.id = 'ready-open';
+			document.body.appendChild(host);
+
+			const btn = document.createElement('button');
+			btn.id = 'btn-open';
+			document.body.appendChild(btn);
+
+			const listenerSpy = vi.spyOn(injector, 'listenerActivity');
+
+			const { id } = injector.register(
+				'#ready-open',
+				{ name: 'ReadyOpen' },
+				{
+					on: {
+						listenAt: '#btn-open',
+						type: 'click',
+						callback: vi.fn()
+					}
+				}
+			);
+
+			injector.run();
+
+			expect(listenerSpy).toHaveBeenCalledWith(id, { type: Action.OPEN });
+		});
+
+		it('registerListener task should bind event without mounting component', () => {
+			const btn = document.createElement('button');
+			btn.id = 'listener-only';
+			document.body.appendChild(btn);
+
+			const addSpy = vi.spyOn(btn, 'addEventListener');
+			const cb = vi.fn();
+			const id = injector.registerListener('#listener-only', 'click', cb);
+			injector.run();
+
+			const context = taskContext.get(id);
+			expect(context?.app).toBeUndefined();
+			expect(context?.appRoot).toBeUndefined();
+			expect(addSpy).toHaveBeenCalledWith(
+				'click',
+				expect.any(Function),
+				expect.objectContaining({ signal: expect.any(AbortSignal) })
+			);
+		});
+	});
+
+	describe('listenerActivity', () => {
+		it('Action.OPEN should bind event and save controller', () => {
+			const btn = document.createElement('button');
+			btn.id = 'open-bind';
+			document.body.appendChild(btn);
+
+			const addSpy = vi.spyOn(btn, 'addEventListener');
+			const { id } = injector.register('#app', { name: 'OpenBind' }, {
+				on: { listenAt: '#open-bind', type: 'click', callback: vi.fn() }
+			});
+
+			injector.listenerActivity(id, { type: Action.OPEN });
+
+			expect(addSpy).toHaveBeenCalledOnce();
+			expect(taskContext.get(id)?.controller).toBeInstanceOf(AbortController);
+		});
+
+		it('Action.OPEN repeated should not bind again when controller exists', () => {
+			const btn = document.createElement('button');
+			btn.id = 'open-repeat';
+			document.body.appendChild(btn);
+
+			const addSpy = vi.spyOn(btn, 'addEventListener');
+			const { id } = injector.register('#app', { name: 'OpenRepeat' }, {
+				on: { listenAt: '#open-repeat', type: 'click', callback: vi.fn() }
+			});
+
+			injector.listenerActivity(id, { type: Action.OPEN });
+			injector.listenerActivity(id, { type: Action.OPEN });
+
+			expect(addSpy).toHaveBeenCalledOnce();
+		});
+
+		it('Action.CLOSE should call controller.abort and clear controller', () => {
+			const { id } = injector.register('#app', { name: 'CloseAction' }, {
+				on: { listenAt: '#close-target', type: 'click', callback: vi.fn() }
+			});
+			const controller = new AbortController();
+			const abortSpy = vi.spyOn(controller, 'abort');
+			const context = taskContext.get(id);
+			if (!context) throw new Error('Task context not found');
+			context.controller = controller;
+
+			injector.listenerActivity(id, { type: Action.CLOSE });
+
+			expect(abortSpy).toHaveBeenCalledOnce();
+			expect(context.controller).toBeUndefined();
+		});
+
+		it('should warn for task without event configuration', () => {
+			const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => { });
+			const { id } = injector.register('#app', { name: 'NoEventConfig' });
+
+			injector.listenerActivity(id, { type: Action.OPEN });
+
+			expect(warnSpy).toHaveBeenCalledWith(
+				expect.stringContaining('has no event binding configured')
+			);
+		});
+
+		it('should warn for unknown action type', () => {
+			const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => { });
+			const { id } = injector.register('#app', { name: 'UnknownAction' }, {
+				on: { listenAt: '#ua', type: 'click', callback: vi.fn() }
+			});
+
+			injector.listenerActivity(id, { type: 'UNKNOWN' as Action });
+
+			expect(warnSpy).toHaveBeenCalledWith(
+				expect.stringContaining('Unknown action type "UNKNOWN"')
+			);
+		});
+	});
+
+	describe('bindActivitySignal', () => {
+		it('should trigger OPEN when signal becomes true and CLOSE when false', async () => {
+			const signal = ref(false);
+			const spy = vi.spyOn(injector, 'listenerActivity');
+			const { id } = injector.register('#app', { name: 'SignalFlow' }, {
+				on: { listenAt: '#sig', type: 'click', callback: vi.fn() }
+			});
+
+			injector.bindActivitySignal(id, signal);
+
+			signal.value = true;
+			await nextTick();
+			signal.value = false;
+			await nextTick();
+
+			expect(spy).toHaveBeenCalledWith(id, { type: Action.CLOSE });
+			expect(spy).toHaveBeenCalledWith(id, { type: Action.OPEN });
+			expect(spy).toHaveBeenCalledTimes(3);
+		});
+
+		it('should stop old watcher before creating new watcher', () => {
+			const signal = ref(false);
+			const { id } = injector.register('#app', { name: 'RebindSignal' }, {
+				on: { listenAt: '#sig2', type: 'click', callback: vi.fn() }
+			});
+
+			const oldWatcher = vi.fn();
+			const context = taskContext.get(id);
+			if (!context) throw new Error('Task context not found');
+			context.watcher = oldWatcher as unknown as WatchHandle;
+
+			injector.bindActivitySignal(id, signal);
+
+			expect(oldWatcher).toHaveBeenCalledOnce();
+			expect(context.watcher).toBeInstanceOf(Function);
+		});
+
+		it('should run immediately once when binding (immediate: true)', () => {
+			const signal = ref(true);
+			const spy = vi.spyOn(injector, 'listenerActivity');
+			const { id } = injector.register('#app', { name: 'ImmediateSignal' }, {
+				on: { listenAt: '#sig3', type: 'click', callback: vi.fn() }
+			});
+
+			injector.bindActivitySignal(id, signal);
+
+			expect(spy).toHaveBeenCalledWith(id, { type: Action.OPEN });
+		});
+	});
+
+	describe('injectComponent (indirect via run and DOM)', () => {
+		it('should append created appRoot div under matchedElement', () => {
+			const host = document.createElement('div');
+			host.id = 'mount-host';
+			document.body.appendChild(host);
+
+			const { id } = injector.register('#mount-host', { name: 'MountTarget' });
+			injector.run();
+
+			const context = taskContext.get(id);
+			expect(context?.appRoot).toBeTruthy();
+			expect(context?.appRoot?.parentElement).toBe(host);
+			expect(context?.appRoot?.id.startsWith('vue-injector-')).toBe(true);
+		});
+
+		it('should skip injection when matchedElement is detached from DOM', () => {
+			const detached = document.createElement('div');
+			detached.id = 'detached-host';
+
+			const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => { });
+			vi.spyOn(DOMWatcher.prototype, 'onDomReady').mockImplementation((_, cb) => {
+				cb(detached);
+				return () => { };
+			});
+
+			const { id } = injector.register('#detached-host', { name: 'DetachedComp' });
+			injector.run();
+
+			expect(taskContext.get(id)?.app).toBeUndefined();
+			expect(warnSpy).toHaveBeenCalledWith(
+				expect.stringContaining('detached from DOM, injection skipped')
+			);
+		});
+
+		it('should skip second mount attempt when task is already mounted', () => {
+			const host = document.createElement('div');
+			host.id = 'already-mounted';
+			document.body.appendChild(host);
+
+			const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => { });
+			let cbRef: ((el: HTMLElement) => void) | undefined;
+			vi.spyOn(DOMWatcher.prototype, 'onDomReady').mockImplementation((_, cb) => {
+				cbRef = cb;
+				return () => { };
+			});
+
+			injector.register('#already-mounted', {
+				name: 'AlreadyMounted',
+				render: () => null
+			});
+			injector.run();
+
+			if (!cbRef) throw new Error('onDomReady callback should be captured');
+			cbRef(host);
+			cbRef(host);
+
+			expect(warnSpy).toHaveBeenCalledWith(
+				expect.stringContaining('already mounted, skipping')
+			);
+		});
+
+		it('alive=true should start onDomAlive observer after successful injection', async () => {
+			const host = document.createElement('div');
+			host.id = 'alive-inject';
+			document.body.appendChild(host);
+
+			const onDomAliveSpy = vi
+				.spyOn(DOMWatcher.prototype, 'onDomAlive')
+				.mockReturnValue(() => { });
+
+			injector.register('#alive-inject', { name: 'AliveInject' }, { alive: true });
+			injector.run();
+			await nextTick();
+
+			expect(onDomAliveSpy).toHaveBeenCalledOnce();
+		});
+
+		it('should catch mount error and remove appRoot', () => {
+			const host = document.createElement('div');
+			host.id = 'mount-error';
+			document.body.appendChild(host);
+
+			const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => { });
+
+			const { id } = injector.register('#mount-error', {
+				name: 'MountErrorComp',
+				setup() {
+					throw new Error('mount failed');
+				}
+			});
+			injector.run();
+
+			expect(errorSpy).toHaveBeenCalledWith(
+				expect.stringContaining('Component mount failed for task'),
+				expect.any(Error)
+			);
+			expect(taskContext.get(id)?.appRoot).toBeUndefined();
+			expect(host.querySelector('[id^="vue-injector-"]')).toBeNull();
+		});
+	});
+
+	describe('destroyed / destroyedAll', () => {
+		it('destroyed should stop alive task first, then call taskContext.destroy', () => {
+			const { id } = injector.register('#app', { name: 'DestroyOne' }, { alive: true });
+			const context = taskContext.get(id);
+			if (!context) throw new Error('Task context not found');
+			context.alive = true;
+
+			const stopAliveSpy = vi.spyOn(injector, 'stopAlive');
+			const destroySpy = vi.spyOn(taskContext, 'destroy');
+
+			injector.destroyed(id);
+
+			expect(stopAliveSpy).toHaveBeenCalledWith(id);
+			expect(destroySpy).toHaveBeenCalledWith(id);
+			expect(stopAliveSpy.mock.invocationCallOrder[0]).toBeLessThan(
+				destroySpy.mock.invocationCallOrder[0]
+			);
+			expect(taskContext.get(id)).toBeUndefined();
+		});
+
+		it('destroyedAll should stop alive tasks then clear all contexts', () => {
+			const aliveA = injector.register('#a', { name: 'AliveA' }, { alive: true }).id;
+			const aliveB = injector.register('#b', { name: 'AliveB' }, { alive: true }).id;
+			const normal = injector.register('#c', { name: 'NormalC' }).id;
+
+			const a = taskContext.get(aliveA);
+			const b = taskContext.get(aliveB);
+			if (!a || !b) throw new Error('Alive contexts should exist');
+			a.alive = true;
+			b.alive = true;
+
+			const stopAliveSpy = vi.spyOn(injector, 'stopAlive');
+			const destroyAllSpy = vi.spyOn(taskContext, 'destroyedAll');
+
+			injector.destroyedAll();
+
+			expect(stopAliveSpy).toHaveBeenCalledWith(aliveA);
+			expect(stopAliveSpy).toHaveBeenCalledWith(aliveB);
+			expect(stopAliveSpy).not.toHaveBeenCalledWith(normal);
+			expect(destroyAllSpy).toHaveBeenCalledOnce();
+			expect(taskContext.get(aliveA)).toBeUndefined();
+			expect(taskContext.get(aliveB)).toBeUndefined();
+			expect(taskContext.get(normal)).toBeUndefined();
+		});
+	});
+
+	describe('setPinia', () => {
+		it('should use provided pinia plugin for later injected component', () => {
+			const host = document.createElement('div');
+			host.id = 'pinia-host';
+			document.body.appendChild(host);
+
+			const install = vi.fn();
+			const fakePinia = { install };
+			injector.setPinia(fakePinia);
+
+			injector.register('#pinia-host', { name: 'PiniaComp' });
+			injector.run();
+
+			expect(install).toHaveBeenCalledOnce();
+		});
+	});
+	describe('keepAlive/stopAlive', () => {
+		describe('keepAlive', () => {
+			it('should warn and return early when called on a pure listener task (no component)', () => {
+				const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => { });
+				const id = injector.registerListener('#app', 'click', () => { });
+				injector.keepAlive(id);
+				expect(warnSpy).toHaveBeenCalledWith(
+					expect.stringContaining('keepAlive is not applicable to non-component task')
+				);
+			});
+			it('should warn and skip when an alive observer is already active (alive=true && isObserver=true)', () => {
+				const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => { });
+				const { id } = injector.register('#app', { name: 'NoDupRun' });
+				injector.keepAlive(id);
+				injector.keepAlive(id);
+				expect(warnSpy).toHaveBeenCalledWith(
+					expect.stringContaining('already has an active alive observer')
+				);
+			});
+			it('should increment aliveEpoch each time keepAlive is called', () => {
+				const { id } = injector.register('#app', { name: 'NoDupRun' });
+				const epoch = taskContext.get(id)?.aliveEpoch;
+				expect(epoch).toBe(0);
+				injector.keepAlive(id);
+				const epoch2 = taskContext.get(id)?.aliveEpoch;
+				expect(epoch2).toBe(1);
+			});
+
+			describe('Case 1 — component already mounted and appRoot.isConnected', () => {
+				it('should call domWatcher.onDomAlive after nextTick when component is mounted and connected', async () => {
+					const div = document.createElement('div');
+					div.id = 'app';
+					document.body.appendChild(div);
+
+					const onDomAliveSpy = vi
+						.spyOn(DOMWatcher.prototype, 'onDomAlive')
+						.mockReturnValue(() => { });
+					const testInjector = new Injector({ alive: true });
+					testInjector.register('#app', { name: 'NoDupRun' }, { alive: true });
+					testInjector.run();
+
+					await nextTick();
+					expect(onDomAliveSpy).toHaveBeenCalledOnce();
+				});
+				it('should pass the matched host element and injectAt selector to onDomAlive', async () => {
+					const div = document.createElement('div');
+					div.id = 'app';
+					document.body.appendChild(div);
+
+					const onDomAliveSpy = vi
+						.spyOn(DOMWatcher.prototype, 'onDomAlive')
+						.mockReturnValue(() => { });
+					const testInjector = new Injector({ alive: true });
+					testInjector.register('#app', { name: 'NoDupRun' });
+					testInjector.run();
+
+					await nextTick();
+
+					const [el, selector, , , root, opts] = onDomAliveSpy.mock.calls[0];
+					expect(el).toBeInstanceOf(HTMLElement);
+					expect(el).toBe(div);
+					expect(selector).toBe('#app');
+					expect(root).toBe(div);
+					expect(opts).toEqual({ once: true, timeout: 5000 });
+				});
+				it('should use document as root when scope is "global"', async () => {
+					const div = document.createElement('div');
+					div.id = 'app';
+					document.body.appendChild(div);
+
+					const onDomAliveSpy = vi
+						.spyOn(DOMWatcher.prototype, 'onDomAlive')
+						.mockReturnValue(() => { });
+					const testInjector = new Injector({ alive: true });
+					testInjector.register(
+						'#app',
+						{ name: 'NoDupRun' },
+						{ alive: true, scope: 'global' }
+					);
+					testInjector.run();
+
+					await nextTick();
+					const [el, selector, , , root, opts] = onDomAliveSpy.mock.calls[0];
+					expect(el).toBeInstanceOf(HTMLElement);
+					expect(el).toBe(document.getElementById('app'));
+					expect(selector).toBe('#app');
+					expect(root).toBe(document);
+					expect(opts).toEqual({ once: true, timeout: 5000 });
+				});
+				it('should use matchedElement as root when scope is "local"', async () => {
+					const div = document.createElement('div');
+					div.id = 'app';
+					document.body.appendChild(div);
+
+					const onDomAliveSpy = vi
+						.spyOn(DOMWatcher.prototype, 'onDomAlive')
+						.mockReturnValue(() => { });
+
+					const testInjector = new Injector({ alive: true });
+					testInjector.register(
+						'#app',
+						{ name: 'NoDupRun' },
+						{ alive: true, scope: 'local' }
+					);
+					testInjector.run();
+
+					await nextTick();
+
+					const [el, selector, , , root, opts] = onDomAliveSpy.mock.calls[0];
+					expect(root).toBe(div);
+					expect(el).toBeInstanceOf(HTMLElement);
+					expect(el).toBe(div);
+					expect(selector).toBe('#app');
+					expect(opts).toEqual({ once: true, timeout: 5000 });
+				});
+				it('should set isObserver=true and assign stopAlive handler after onDomAlive is called', async () => {
+					const div = document.createElement('div');
+					div.id = 'app';
+					document.body.appendChild(div);
+
+					injector.register('#app', { name: 'NoDupRun' }, { alive: true });
+					injector.run();
+
+					await nextTick();
+
+					const taskContext = injector.getTaskContext();
+					const ctx = taskContext?.get('NoDupRun@#app');
+					expect(ctx?.isObserver).toBe(true);
+					expect(ctx?.stopAlive).toBeInstanceOf(Function);
+				});
+
+				it('should abort setup and call the returned stopHandler if alive was cancelled during nextTick', async () => {
+					const div = document.createElement('div');
+					div.id = 'abort-test';
+					document.body.appendChild(div);
+
+					const onDomAliveSpy = vi
+						.spyOn(DOMWatcher.prototype, 'onDomAlive')
+						.mockReturnValue(vi.fn());
+
+					const { id } = injector.register('#abort-test', {
+						name: 'AbortTest'
+					});
+					injector.run();
+
+					// Cancel alive synchronously before nextTick fires,
+					// simulating "alive was cancelled during nextTick"
+					injector.keepAlive(id);
+					injector.stopAlive(id);
+
+					await nextTick();
+
+					// The first guard (!context.alive) in the nextTick callback should
+					// short-circuit immediately, so onDomAlive must never be called
+					expect(onDomAliveSpy).not.toHaveBeenCalled();
+					expect(taskContext.get(id)?.isObserver).toBe(false);
+				});
+				it('should abort setup if aliveEpoch changed during nextTick (stale epoch guard)', async () => {
+					const div = document.createElement('div');
+					div.id = 'epoch-guard';
+					document.body.appendChild(div);
+
+					const { id } = injector.register(
+						'#epoch-guard',
+						{
+							name: 'EpochGuard'
+						},
+						{ alive: true, scope: 'local' }
+					);
+					injector.run();
+
+					const fakeStopHandler = vi.fn();
+					// Mock onDomAlive to simulate epoch changing *after* onDomAlive is called
+					// but before isObserver is assigned (i.e. the second guard is the one that fires)
+					vi.spyOn(DOMWatcher.prototype, 'onDomAlive').mockImplementation(() => {
+						// Calling keepAlive again bumps aliveEpoch, making the current epoch stale
+						injector.keepAlive(id);
+						return fakeStopHandler;
+					});
+
+					injector.keepAlive(id);
+					await nextTick();
+
+					// The second guard inside the nextTick callback detects a stale epoch and
+					// must call the returned stopHandler to clean up the observer
+					expect(fakeStopHandler).toHaveBeenCalledOnce();
+					// isObserver must remain false because the stale setup was aborted
+					expect(taskContext.get(id)?.isObserver).toBe(false);
+				});
+			});
+
+			describe('Case 2 — component not yet mounted (app is undefined)', () => {
+				it('should call domWatcher.onDomReady to wait for the target element when app is undefined', () => {
+					const onDomReadySpy = vi.spyOn(DOMWatcher.prototype, 'onDomReady');
+					const { id } = injector.register('#app', { name: 'App' });
+					injector.keepAlive(id);
+
+					expect(onDomReadySpy).toHaveBeenCalledOnce();
+				});
+				it('should set isObserver=true and assign a cancellable stopAlive handler', () => {
+					const { id } = injector.register('#app', { name: 'App' });
+					injector.keepAlive(id);
+
+					expect(taskContext.get(id)?.isObserver).toBe(true);
+					expect(taskContext.get(id)?.stopAlive).toBeInstanceOf(Function);
+				});
+				it('should not invoke handleInjectionReady if the observer was cancelled before element appears', () => {
+					const stopHandler = vi.fn();
+					const onDomReadySpy = vi
+						.spyOn(DOMWatcher.prototype, 'onDomReady')
+						.mockReturnValue(stopHandler);
+					const handleInjectionReadySpy = vi.spyOn(
+						injector as unknown as {
+							handleInjectionReady: (...args: unknown[]) => unknown;
+						},
+						'handleInjectionReady'
+					);
+
+					const { id, stopAlive } = injector.register('#app', { name: 'App' });
+					injector.keepAlive(id);
+					stopAlive();
+
+					expect(onDomReadySpy).toHaveBeenCalled();
+					expect(stopHandler).toHaveBeenCalled();
+					expect(handleInjectionReadySpy).not.toHaveBeenCalled();
+				});
+				it('should not invoke handleInjectionReady if aliveEpoch changed before element appears', () => {
+					const div = document.createElement('div');
+					div.id = 'app';
+					document.body.appendChild(div);
+
+					const stopHandler = () => { };
+
+					const onDomReadySpy = vi
+						.spyOn(DOMWatcher.prototype, 'onDomReady')
+						.mockImplementation((selector, cb, document, opts) => {
+							const ctx = taskContext.get(id);
+							if (ctx?.aliveEpoch) ctx.aliveEpoch += 1;
+							cb(div);
+							return stopHandler;
+						});
+
+					const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => { });
+
+					const handleInjectionReadySpy = vi.spyOn(
+						injector as unknown as {
+							handleInjectionReady: (...args: unknown[]) => unknown;
+						},
+						'handleInjectionReady'
+					);
+
+					const { id } = injector.register('#app', { name: 'App' });
+					injector.keepAlive(id);
+
+					expect(consoleSpy).toHaveBeenCalledWith(
+						expect.stringContaining('alive epoch changed before element appears')
+					);
+					expect(onDomReadySpy).toHaveBeenCalled();
+					expect(handleInjectionReadySpy).not.toHaveBeenCalled();
+				});
+			});
+		});
+
+		describe('stopAlive', () => {
+			it('should warn when stopAlive is called and alive is false', () => {
+				const div = document.createElement('div');
+				div.id = 'app';
+				document.body.appendChild(div);
+
+				const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => { });
+
+				const { stopAlive } = injector.register('#app', { name: 'App' }, { alive: false });
+				stopAlive();
+
+				expect(consoleSpy).toHaveBeenCalledWith(
+					expect.stringContaining('has no active alive observer to stop')
+				);
+			});
+			it('should set alive=false and isObserver=false after stopAlive is called', () => {
+				const div = document.createElement('div');
+				div.id = 'app';
+				document.body.appendChild(div);
+
+				const { stopAlive } = injector.register('#app', { name: 'App' }, { alive: true });
+				stopAlive();
+
+				const taskContext = injector.getTaskContext();
+				expect(taskContext?.get('App@#app')?.alive).toBe(false);
+				expect(taskContext?.get('App@#app')?.isObserver).toBe(false);
+			});
+
+			it('should set stopAlive handler to undefined after stopAlive is called', () => {
+				const div = document.createElement('div');
+				div.id = 'app';
+				document.body.appendChild(div);
+
+				const { stopAlive } = injector.register('#app', { name: 'App' }, { alive: true });
+				stopAlive();
+
+				const taskContext = injector.getTaskContext();
+				expect(taskContext?.get('App@#app')?.stopAlive).toBeUndefined();
+			});
+			it('should increment aliveEpoch when stopAlive is called to invalidate in-flight async callbacks', async () => {
+				const div = document.createElement('div');
+				div.id = 'app';
+				document.body.appendChild(div);
+
+				const { stopAlive } = injector.register('#app', { name: 'App' }, { alive: true });
+				injector.run();
+
+				stopAlive();
+
+				await nextTick();
+
+				const taskContext = injector.getTaskContext();
+				expect(taskContext?.get('App@#app')?.aliveEpoch).toBe(1);
+			});
+			it('should invoke the stored stopAlive handler to tear down the active observer', () => {
+				const div = document.createElement('div');
+				div.id = 'app';
+				document.body.appendChild(div);
+
+				const fakeStopHandler = vi.fn();
+				const { id } = injector.register('#app', { name: 'App' }, { alive: true });
+
+				const taskContext = injector.getTaskContext();
+				const ctx = taskContext?.get(id);
+				if (!ctx) throw new Error('Task context should exist for registered component');
+
+				ctx.stopAlive = fakeStopHandler;
+				ctx.alive = true;
+				ctx.isObserver = true;
+
+				injector.stopAlive(id);
+
+				expect(fakeStopHandler).toHaveBeenCalledOnce();
+				expect(ctx.alive).toBe(false);
+				expect(ctx.isObserver).toBe(false);
+				expect(ctx.stopAlive).toBeUndefined();
+			});
+		});
+	});
+});

--- a/src/core/Injector.ts
+++ b/src/core/Injector.ts
@@ -224,7 +224,12 @@ export class Injector {
 			const stopReadyObserver = this.domWatcher.onDomReady(
 				context.componentInjectAt,
 				(el): void => {
-					if (cancelled || !context.alive || context.aliveEpoch !== aliveEpoch) return;
+					if (cancelled || !context.alive || context.aliveEpoch !== aliveEpoch) {
+						console.warn(
+							`[vue-injector] Task "${id}" alive epoch changed before element appears`
+						);
+						return;
+					}
 					this.handleInjectionReady(el, id);
 				},
 				document,
@@ -262,6 +267,10 @@ export class Injector {
 		stopHandler?.();
 	}
 
+	public getTaskContext(): TaskContext | undefined {
+		return this.taskContext;
+	}
+
 	public setPinia<T extends Plugin>(pinia: T): void {
 		this.taskContext.setPinia(pinia);
 	}
@@ -283,7 +292,7 @@ export class Injector {
 		}
 		this.taskContext.destroyedAll();
 	}
-
+	// TODO: add config option to enable flush sync or pre
 	public bindActivitySignal(id: string, source: WatchSource<boolean>): void {
 		// Bind a reactive signal to control automatic listener attach/detach for this task
 		const context: InjectionContext | undefined = this.taskContext.get(id);


### PR DESCRIPTION
This pull request introduces improvements to the `Injector` class in `src/core/Injector.ts`, focusing on better debugging, API enhancements, and internal documentation. The most notable changes are the addition of a warning log for debugging task lifecycle issues, a new getter method for accessing the task context, and an inline TODO comment for future configuration options.

Testing support 
* Added a `Injector.test.ts` file to support testing Injector class 

Debugging and diagnostics improvements:
* Added a `console.warn` message when a task's alive epoch changes before the DOM element appears, aiding in diagnosing lifecycle issues.

API enhancements:
* Introduced a new public `getTaskContext()` method to allow external access to the injector's `taskContext`.

Internal documentation:
* Added a TODO comment indicating a future plan to add a config option for flush sync or pre in the `bindActivitySignal` method.