### PR TITLE
refactor:Remove aliveEpoch from alive observers

### DIFF
--- a/README.CN.md
+++ b/README.CN.md
@@ -362,10 +362,10 @@ injector.register('#app', App, {
 | `listener:open` | `taskId`, `kind`, `injectAt`, `status`, `meta.listenerEvent`, `meta.listenAt` |
 | `listener:close` | `taskId`, `kind`, `injectAt`, `status`, `meta.listenerEvent`, `meta.listenAt` |
 | `listener:attachFail` | `taskId`, `kind`, `injectAt`, `status`, `error`, `meta.listenerEvent`, `meta.listenAt` |
-| `alive:enable` | `taskId`, `kind`, `injectAt`, `status`, `meta.scope`, `meta.aliveEpoch` |
-| `alive:disable` | `taskId`, `kind`, `injectAt`, `status`, `meta.scope`, `meta.aliveEpoch` |
-| `alive:observeStart` | `taskId`, `kind`, `injectAt`, `status`, `meta.scope`, `meta.aliveEpoch`, `meta.observerMode` |
-| `alive:observeStop` | `taskId`, `kind`, `injectAt`, `status`, `meta.scope`, `meta.aliveEpoch`, `meta.observerMode` |
+| `alive:enable` | `taskId`, `kind`, `injectAt`, `status`, `meta.scope` |
+| `alive:disable` | `taskId`, `kind`, `injectAt`, `status`, `meta.scope` |
+| `alive:observeStart` | `taskId`, `kind`, `injectAt`, `status`, `meta.scope`, `meta.observerMode` |
+| `alive:observeStop` | `taskId`, `kind`, `injectAt`, `status`, `meta.scope`, `meta.observerMode` |
 | `task:statusChange` | `taskId`, `kind`, `injectAt`, `status`, `preStatus` |
 | `task:active` | `taskId`, `kind`, `injectAt`, `status`, `preStatus` |
 | `task:beforeReset` | `taskId`, `kind`, `injectAt`, `status` |
@@ -398,7 +398,7 @@ injector.register('#app', App, {
 - 大多数任务相关事件都提供规范化基础字段：`taskId`、`kind`、`injectAt`、`status`。
 - 状态迁移事件提供 `preStatus`（例如：`task:statusChange`、`task:active`、`task:afterReset`、`task:afterDestroy`）。
 - 耗时类事件提供 `durationMs`（例如：`dom:readyFound`、`dom:readyTimeout`、`dom:restored`）。
-- 事件专属信息放入 `meta`（例如：`run:start` 统计、`listener:*` 绑定信息、`alive:*` scope/epoch/mode）。
+- 事件专属信息放入 `meta`（例如：`run:start` 统计、`listener:*` 绑定信息、`alive:*` scope/mode）。
 - DOM watcher 事件由运行时工厂注入任务上下文，`DOMWatcher` 本身保持业务无关。
 
 ### `Injector.enableAlive(taskId: string): void`

--- a/README.md
+++ b/README.md
@@ -361,10 +361,10 @@ Lifecycle event payloads:
 | `listener:open` | `taskId`, `kind`, `injectAt`, `status`, `meta.listenerEvent`, `meta.listenAt` |
 | `listener:close` | `taskId`, `kind`, `injectAt`, `status`, `meta.listenerEvent`, `meta.listenAt` |
 | `listener:attachFail` | `taskId`, `kind`, `injectAt`, `status`, `error`, `meta.listenerEvent`, `meta.listenAt` |
-| `alive:enable` | `taskId`, `kind`, `injectAt`, `status`, `meta.scope`, `meta.aliveEpoch` |
-| `alive:disable` | `taskId`, `kind`, `injectAt`, `status`, `meta.scope`, `meta.aliveEpoch` |
-| `alive:observeStart` | `taskId`, `kind`, `injectAt`, `status`, `meta.scope`, `meta.aliveEpoch`, `meta.observerMode` |
-| `alive:observeStop` | `taskId`, `kind`, `injectAt`, `status`, `meta.scope`, `meta.aliveEpoch`, `meta.observerMode` |
+| `alive:enable` | `taskId`, `kind`, `injectAt`, `status`, `meta.scope` |
+| `alive:disable` | `taskId`, `kind`, `injectAt`, `status`, `meta.scope` |
+| `alive:observeStart` | `taskId`, `kind`, `injectAt`, `status`, `meta.scope`, `meta.observerMode` |
+| `alive:observeStop` | `taskId`, `kind`, `injectAt`, `status`, `meta.scope`, `meta.observerMode` |
 | `task:statusChange` | `taskId`, `kind`, `injectAt`, `status`, `preStatus` |
 | `task:active` | `taskId`, `kind`, `injectAt`, `status`, `preStatus` |
 | `task:beforeReset` | `taskId`, `kind`, `injectAt`, `status` |
@@ -397,7 +397,7 @@ Payload conventions:
 - Most task-related events carry normalized base fields: `taskId`, `kind`, `injectAt`, `status`.
 - Transition events include `preStatus` (for example: `task:statusChange`, `task:active`, `task:afterReset`, `task:afterDestroy`).
 - Time-based events include `durationMs` (for example: `dom:readyFound`, `dom:readyTimeout`, `dom:restored`).
-- Event-specific details are provided in `meta` (for example: `run:start` stats, `listener:*` binding info, `alive:*` scope/epoch/mode).
+- Event-specific details are provided in `meta` (for example: `run:start` stats, `listener:*` binding info, `alive:*` scope/mode).
 - DOM watcher events are emitted with task context from runtime factories, while `DOMWatcher` itself remains business-agnostic.
 
 ### `Injector.enableAlive(taskId: string): void`

--- a/__test__/TaskLifeCycle.test.ts
+++ b/__test__/TaskLifeCycle.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { type App, nextTick } from 'vue';
+import { type App } from 'vue';
 import { ObserverHub } from '../src/core/hooks/ObserverHub';
 import type { ObserveEvent } from '../src/core/hooks/type';
 import { createObserveEmitter } from '../src/core/hooks/util';
@@ -81,7 +81,7 @@ describe('TaskLifeCycle', () => {
 		);
 	});
 
-	it('should start onDomAlive in enableAlive case 1 (mounted and connected)', async () => {
+	it('should start onDomAlive in enableAlive case 1 (mounted and connected)', () => {
 		const host = document.createElement('div');
 		host.id = 'mounted-host';
 		document.body.appendChild(host);
@@ -100,7 +100,6 @@ describe('TaskLifeCycle', () => {
 				appRoot,
 				alive: false,
 				isObserver: false,
-				aliveEpoch: 0,
 				scope: 'local'
 			})
 		);
@@ -109,14 +108,13 @@ describe('TaskLifeCycle', () => {
 		const aliveSpy = vi.spyOn(DOMWatcher, 'onDomAlive').mockReturnValue(stopHandler);
 
 		lifeCycle.enableAlive('mounted-task');
-		await nextTick();
 
 		expect(aliveSpy).toHaveBeenCalledOnce();
 		expect(taskContext.get<ComponentTask>('mounted-task')?.disableAlive).toBe(stopHandler);
 		expect(taskContext.get<ComponentTask>('mounted-task')?.isObserver).toBe(true);
 	});
 
-	it('should call reset and onTargetReady from onDomAlive callbacks in case 1', async () => {
+	it('should call reset and onTargetReady from onDomAlive callbacks in case 1', () => {
 		const host = document.createElement('div');
 		host.id = 'mounted-host-callback';
 		document.body.appendChild(host);
@@ -135,7 +133,6 @@ describe('TaskLifeCycle', () => {
 				appRoot,
 				alive: false,
 				isObserver: false,
-				aliveEpoch: 0,
 				scope: 'local'
 			})
 		);
@@ -150,7 +147,6 @@ describe('TaskLifeCycle', () => {
 			});
 
 		lifeCycle.enableAlive('mounted-callback-task');
-		await nextTick();
 
 		expect(aliveSpy).toHaveBeenCalledOnce();
 		expect(resetSpy).toHaveBeenCalledWith('mounted-callback-task');
@@ -180,7 +176,6 @@ describe('TaskLifeCycle', () => {
 				appRoot,
 				alive: false,
 				isObserver: false,
-				aliveEpoch: 0,
 				scope: 'local'
 			})
 		);
@@ -197,8 +192,9 @@ describe('TaskLifeCycle', () => {
 		expect(taskContext.get<ComponentTask>('shadow-task')?.isObserver).toBe(false);
 	});
 
-	it('should abort setup and call the returned stopHandler if alive was cancelled during nextTick', async () => {
-		const onDomAliveSpy = vi.spyOn(DOMWatcher, 'onDomAlive').mockReturnValue(vi.fn());
+	it('should stop mounted alive observer when disabled right after setup', () => {
+		const stopHandler = vi.fn();
+		const onDomAliveSpy = vi.spyOn(DOMWatcher, 'onDomAlive').mockReturnValue(stopHandler);
 		const appRoot = document.createElement('div');
 		appRoot.id = 'app';
 		document.body.appendChild(appRoot);
@@ -213,25 +209,19 @@ describe('TaskLifeCycle', () => {
 				componentInjectAt: '#app',
 				component: { name: 'AliveComp' },
 				app: { unmount: vi.fn() } as unknown as App,
-				aliveEpoch: 0,
 				scope: 'local'
 			})
 		);
 
-		// Cancel alive synchronously before nextTick fires,
-		// simulating "alive was cancelled during nextTick"
 		lifeCycle.enableAlive('alive-task');
 		lifeCycle.disableAlive('alive-task');
 
-		await nextTick();
-
-		// The first guard (!context.alive) in the nextTick callback should
-		// short-circuit immediately, so onDomAlive must never be called
-		expect(onDomAliveSpy).not.toHaveBeenCalled();
+		expect(onDomAliveSpy).toHaveBeenCalledOnce();
+		expect(stopHandler).toHaveBeenCalledOnce();
 		expect(taskContext.get<ComponentTask>('alive-task')?.isObserver).toBe(false);
 	});
 
-	it('should abort setup if aliveEpoch changed during nextTick (stale epoch guard)', async () => {
+	it('should keep mounted observer active when setup succeeds', () => {
 		const appRoot = document.createElement('div');
 		appRoot.id = 'app';
 		document.body.appendChild(appRoot);
@@ -246,30 +236,18 @@ describe('TaskLifeCycle', () => {
 				componentInjectAt: '#app',
 				component: { name: 'AliveComp' },
 				app: { unmount: vi.fn() } as unknown as App,
-				aliveEpoch: 0,
 				scope: 'local'
 			})
 		);
 
 		const fakeStopHandler = vi.fn();
-		// Simulate epoch changing after onDomAlive returns but before the second guard check.
-		// Mutating epoch directly avoids recursive enableAlive scheduling.
-		vi.spyOn(DOMWatcher, 'onDomAlive').mockImplementation(() => {
-			const ctx = taskContext.get<ComponentTask>('alive-task');
-			if (ctx?.aliveEpoch) {
-				ctx.aliveEpoch += 1;
-			}
-			return fakeStopHandler;
-		});
+		const onDomAliveSpy = vi.spyOn(DOMWatcher, 'onDomAlive').mockReturnValue(fakeStopHandler);
 
 		lifeCycle.enableAlive('alive-task');
-		await nextTick();
 
-		// The second guard inside the nextTick callback detects a stale epoch and
-		// must call the returned stopHandler to clean up the observer
-		expect(fakeStopHandler).toHaveBeenCalledOnce();
-		// isObserver must remain false because the stale setup was aborted
-		expect(taskContext.get<ComponentTask>('alive-task')?.isObserver).toBe(false);
+		expect(onDomAliveSpy).toHaveBeenCalledOnce();
+		expect(fakeStopHandler).not.toHaveBeenCalled();
+		expect(taskContext.get<ComponentTask>('alive-task')?.isObserver).toBe(true);
 	});
 
 	it('should reset and then onDomReady in enableAlive case 2 (disconnected appRoot)', () => {
@@ -290,7 +268,6 @@ describe('TaskLifeCycle', () => {
 				appRoot,
 				alive: false,
 				isObserver: false,
-				aliveEpoch: 0,
 				scope: 'local'
 			})
 		);
@@ -315,7 +292,6 @@ describe('TaskLifeCycle', () => {
 				component: { name: 'Case3Comp' },
 				alive: false,
 				isObserver: false,
-				aliveEpoch: 0,
 				scope: 'local'
 			})
 		);
@@ -343,7 +319,6 @@ describe('TaskLifeCycle', () => {
 				component: { name: 'Case3CancelledComp' },
 				alive: false,
 				isObserver: false,
-				aliveEpoch: 0,
 				scope: 'local'
 			})
 		);
@@ -360,12 +335,12 @@ describe('TaskLifeCycle', () => {
 		readyCallback?.(document.createElement('div'));
 
 		expect(warnSpy).toHaveBeenCalledWith(
-			expect.stringContaining('alive epoch changed before element appears')
+			expect.stringContaining('alive state changed before element appears')
 		);
 		expect(onTargetReady).not.toHaveBeenCalled();
 	});
 
-	it('should warn and skip onTargetReady when case 3 callback sees stale aliveEpoch', () => {
+	it('should warn and skip onTargetReady when case 3 callback sees inactive alive state', () => {
 		taskContext.set(
 			'case3-stale-task',
 			createComponentTask({
@@ -375,7 +350,6 @@ describe('TaskLifeCycle', () => {
 				component: { name: 'Case3StaleComp' },
 				alive: false,
 				isObserver: false,
-				aliveEpoch: 0,
 				scope: 'local'
 			})
 		);
@@ -389,13 +363,13 @@ describe('TaskLifeCycle', () => {
 
 		lifeCycle.enableAlive('case3-stale-task');
 		const context = taskContext.get<ComponentTask>('case3-stale-task');
-		if (context?.aliveEpoch) {
-			context.aliveEpoch += 1;
+		if (context) {
+			context.alive = false;
 		}
 		readyCallback?.(document.createElement('div'));
 
 		expect(warnSpy).toHaveBeenCalledWith(
-			expect.stringContaining('alive epoch changed before element appears')
+			expect.stringContaining('alive state changed before element appears')
 		);
 		expect(onTargetReady).not.toHaveBeenCalled();
 	});
@@ -413,7 +387,6 @@ describe('TaskLifeCycle', () => {
 				component: { name: 'CancelComp' },
 				alive: false,
 				isObserver: false,
-				aliveEpoch: 0,
 				scope: 'local'
 			})
 		);
@@ -436,7 +409,6 @@ describe('TaskLifeCycle', () => {
 				component: { name: 'DisableComp' },
 				alive: true,
 				isObserver: true,
-				aliveEpoch: 2,
 				disableAlive: stop
 			})
 		);
@@ -448,7 +420,6 @@ describe('TaskLifeCycle', () => {
 		expect(context?.alive).toBe(false);
 		expect(context?.isObserver).toBe(false);
 		expect(context?.disableAlive).toBeUndefined();
-		expect(context?.aliveEpoch).toBe(3);
 	});
 
 	it('should warn when disableAlive task is missing', () => {
@@ -579,7 +550,7 @@ describe('TaskLifeCycle', () => {
 		expect(resetAllSpy).toHaveBeenCalledOnce();
 	});
 
-	it('should emit alive and task lifecycle events', async () => {
+	it('should emit alive and task lifecycle events', () => {
 		const observer = new ObserverHub();
 		const events: string[] = [];
 		observer.onAny((event) => {
@@ -615,7 +586,6 @@ describe('TaskLifeCycle', () => {
 				appRoot,
 				alive: false,
 				isObserver: false,
-				aliveEpoch: 0,
 				scope: 'local'
 			})
 		);
@@ -623,7 +593,6 @@ describe('TaskLifeCycle', () => {
 		vi.spyOn(DOMWatcher, 'onDomAlive').mockReturnValue(() => {});
 
 		lifecycleWithObserver.enableAlive('obs-life-task');
-		await nextTick();
 		lifecycleWithObserver.disableAlive('obs-life-task');
 		lifecycleWithObserver.reset('obs-life-task');
 		lifecycleWithObserver.destroy('obs-life-task');
@@ -640,7 +609,7 @@ describe('TaskLifeCycle', () => {
 		expect(events).toContain('task:afterDestroy');
 	});
 
-	it('should emit normalized alive payloads for mounted observer mode', async () => {
+	it('should emit normalized alive payloads for mounted observer mode', () => {
 		const observer = new ObserverHub();
 		const lifecycleWithObserver = new TaskLifeCycle(
 			taskContext,
@@ -672,7 +641,6 @@ describe('TaskLifeCycle', () => {
 				appRoot,
 				alive: false,
 				isObserver: false,
-				aliveEpoch: 0,
 				scope: 'global'
 			})
 		);
@@ -687,7 +655,6 @@ describe('TaskLifeCycle', () => {
 		});
 
 		lifecycleWithObserver.enableAlive('alive-mounted-task');
-		await nextTick();
 		lifecycleWithObserver.disableAlive('alive-mounted-task');
 
 		expect(aliveEvents.find((event) => event.name === 'alive:enable')).toMatchObject({
@@ -697,8 +664,7 @@ describe('TaskLifeCycle', () => {
 			injectAt: '#alive-mounted-host',
 			status: 'idle',
 			meta: {
-				scope: 'global',
-				aliveEpoch: 1
+				scope: 'global'
 			}
 		});
 
@@ -715,7 +681,6 @@ describe('TaskLifeCycle', () => {
 			status: 'idle',
 			meta: {
 				scope: 'global',
-				aliveEpoch: 1,
 				observerMode: 'mounted'
 			}
 		});
@@ -727,8 +692,7 @@ describe('TaskLifeCycle', () => {
 			injectAt: '#alive-mounted-host',
 			status: 'idle',
 			meta: {
-				scope: 'global',
-				aliveEpoch: 2
+				scope: 'global'
 			}
 		});
 
@@ -745,7 +709,6 @@ describe('TaskLifeCycle', () => {
 			status: 'idle',
 			meta: {
 				scope: 'global',
-				aliveEpoch: 2,
 				observerMode: 'mounted'
 			}
 		});
@@ -775,7 +738,6 @@ describe('TaskLifeCycle', () => {
 				component: { name: 'AliveAwaitComp' },
 				alive: false,
 				isObserver: false,
-				aliveEpoch: 0,
 				scope: 'local'
 			})
 		);
@@ -806,7 +768,6 @@ describe('TaskLifeCycle', () => {
 			status: 'idle',
 			meta: {
 				scope: 'local',
-				aliveEpoch: 1,
 				observerMode: 'await-target'
 			}
 		});
@@ -818,8 +779,7 @@ describe('TaskLifeCycle', () => {
 			injectAt: '#alive-await-host',
 			status: 'idle',
 			meta: {
-				scope: 'local',
-				aliveEpoch: 2
+				scope: 'local'
 			}
 		});
 

--- a/__test__/TaskRegister.test.ts
+++ b/__test__/TaskRegister.test.ts
@@ -43,7 +43,6 @@ describe('TaskRegister', () => {
 				componentInjectAt: '#app',
 				component,
 				timeout: 5000,
-				aliveEpoch: 0,
 				isObserver: false
 			})
 		);
@@ -65,7 +64,6 @@ describe('TaskRegister', () => {
 				alive: true,
 				scope: 'global',
 				timeout: 5000,
-				aliveEpoch: 0,
 				isObserver: false
 			})
 		);
@@ -96,7 +94,6 @@ describe('TaskRegister', () => {
 				component,
 				withEvent: true,
 				timeout: 5000,
-				aliveEpoch: 0,
 				isObserver: false,
 				listener: {
 					listenAt: '#btn',

--- a/__test__/TaskRunner.test.ts
+++ b/__test__/TaskRunner.test.ts
@@ -785,12 +785,13 @@ describe('TaskRunner', () => {
 		expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Unknown action type'));
 	});
 
-	it('should start onDomAlive for alive component after successful mount', async () => {
+	it('should start onDomAlive for alive component after successful mount', () => {
 		const host = document.createElement('div');
 		host.id = 'alive-host';
 		document.body.appendChild(host);
 
-		const onDomAliveSpy = vi.spyOn(DOMWatcher, 'onDomAlive').mockReturnValue(() => {});
+		const stopHandler = vi.fn();
+		const onDomAliveSpy = vi.spyOn(DOMWatcher, 'onDomAlive').mockReturnValue(stopHandler);
 		taskContext.set(
 			'alive-task',
 			createComponentTask({
@@ -801,15 +802,15 @@ describe('TaskRunner', () => {
 				component: { name: 'AliveComp', render: () => null },
 				alive: true,
 				isObserver: false,
-				aliveEpoch: 0,
 				scope: 'local'
 			})
 		);
 
 		taskRunner.onTargetReady(host, 'alive-task');
-		await nextTick();
 
 		expect(onDomAliveSpy).toHaveBeenCalledOnce();
+		expect(stopHandler).not.toHaveBeenCalled();
+		expect(taskContext.get<ComponentTask>('alive-task')?.disableAlive).toBe(stopHandler);
 		expect(taskContext.get<ComponentTask>('alive-task')?.isObserver).toBe(true);
 	});
 
@@ -1059,7 +1060,7 @@ describe('TaskRunner', () => {
 		);
 	});
 
-	it('should use document root for onDomAlive when scope is global', async () => {
+	it('should use document root for onDomAlive when scope is global', () => {
 		const host = document.createElement('div');
 		host.id = 'global-alive-host';
 		document.body.appendChild(host);
@@ -1075,19 +1076,17 @@ describe('TaskRunner', () => {
 				component: { name: 'GlobalAliveComp', render: () => null },
 				alive: true,
 				isObserver: false,
-				aliveEpoch: 0,
 				scope: 'global'
 			})
 		);
 
 		taskRunner.onTargetReady(host, 'global-alive-task');
-		await nextTick();
 
 		expect(aliveSpy).toHaveBeenCalledOnce();
 		expect(aliveSpy.mock.calls[0][4]).toBe(document);
 	});
 
-	it('should call stopHandler when alive setup becomes stale after onDomAlive call', async () => {
+	it('should call stopHandler when alive setup is cancelled during onDomAlive setup', () => {
 		const host = document.createElement('div');
 		host.id = 'stale-alive-host';
 		document.body.appendChild(host);
@@ -1102,7 +1101,6 @@ describe('TaskRunner', () => {
 				component: { name: 'StaleAliveComp', render: () => null },
 				alive: true,
 				isObserver: false,
-				aliveEpoch: 0,
 				scope: 'local'
 			})
 		);
@@ -1111,24 +1109,24 @@ describe('TaskRunner', () => {
 		vi.spyOn(DOMWatcher, 'onDomAlive').mockImplementation(() => {
 			const ctx = taskContext.get<ComponentTask>('stale-alive-task');
 			if (ctx) {
-				ctx.aliveEpoch = (ctx.aliveEpoch ?? 0) + 1;
+				ctx.alive = false;
 			}
 			return stopHandler;
 		});
 
 		taskRunner.onTargetReady(host, 'stale-alive-task');
-		await nextTick();
 
 		expect(stopHandler).toHaveBeenCalledOnce();
 		expect(taskContext.get<ComponentTask>('stale-alive-task')?.isObserver).toBe(false);
 	});
 
-	it('should short-circuit alive setup when alive is cancelled before nextTick', async () => {
+	it('should assign alive observer handler immediately when setup succeeds', () => {
 		const host = document.createElement('div');
 		host.id = 'cancel-alive-host';
 		document.body.appendChild(host);
 
-		const onDomAliveSpy = vi.spyOn(DOMWatcher, 'onDomAlive').mockReturnValue(() => {});
+		const stopHandler = vi.fn();
+		const onDomAliveSpy = vi.spyOn(DOMWatcher, 'onDomAlive').mockReturnValue(stopHandler);
 		taskContext.set(
 			'cancel-alive-task',
 			createComponentTask({
@@ -1139,23 +1137,19 @@ describe('TaskRunner', () => {
 				component: { name: 'CancelAliveComp', render: () => null },
 				alive: true,
 				isObserver: false,
-				aliveEpoch: 0,
 				scope: 'local'
 			})
 		);
 
 		taskRunner.onTargetReady(host, 'cancel-alive-task');
 		const context = taskContext.get<ComponentTask>('cancel-alive-task');
-		if (context) {
-			context.alive = false;
-		}
-		await nextTick();
 
-		expect(onDomAliveSpy).not.toHaveBeenCalled();
-		expect(taskContext.get<ComponentTask>('cancel-alive-task')?.isObserver).toBe(false);
+		expect(onDomAliveSpy).toHaveBeenCalledOnce();
+		expect(context?.disableAlive).toBe(stopHandler);
+		expect(context?.isObserver).toBe(true);
 	});
 
-	it('should call reset and onTargetReady from onDomAlive callbacks', async () => {
+	it('should call reset and onTargetReady from onDomAlive callbacks', () => {
 		const host = document.createElement('div');
 		host.id = 'alive-callback-host';
 		document.body.appendChild(host);
@@ -1170,7 +1164,6 @@ describe('TaskRunner', () => {
 				component: { name: 'AliveCallbackComp', render: () => null },
 				alive: true,
 				isObserver: false,
-				aliveEpoch: 0,
 				scope: 'local'
 			})
 		);
@@ -1189,10 +1182,9 @@ describe('TaskRunner', () => {
 		);
 
 		taskRunner.onTargetReady(host, 'alive-callback-task');
-		await nextTick();
 
 		expect(resetSpy).toHaveBeenCalledWith('alive-callback-task');
-		expect(taskContext.get('alive-callback-task')?.taskStatus).toBe('idle');
+		expect(taskContext.get('alive-callback-task')?.taskStatus).toBe('active');
 	});
 	it('should set Task`s timeout config correctly', async () => {
 		const onDomReadySpy = vi.spyOn(DOMWatcher, 'onDomReady');

--- a/__test__/factory/TaskFactor.ts
+++ b/__test__/factory/TaskFactor.ts
@@ -28,7 +28,6 @@ export type CreateComponentTaskInput = TaskBaseInput & {
 	app?: App<Element>;
 	appRoot?: HTMLElement;
 	instance?: ComponentPublicInstance;
-	aliveEpoch?: number;
 	isObserver?: boolean;
 	disableAlive?: () => void;
 };
@@ -63,7 +62,6 @@ export function createTask(input: CreateComponentTaskInput | CreateListenerTaskI
 			...(input.app ? { app: input.app } : {}),
 			...(input.appRoot ? { appRoot: input.appRoot } : {}),
 			...(input.instance ? { instance: input.instance } : {}),
-			...(input.aliveEpoch !== undefined ? { aliveEpoch: input.aliveEpoch } : {}),
 			...(input.isObserver !== undefined ? { isObserver: input.isObserver } : {}),
 			...(input.disableAlive ? { disableAlive: input.disableAlive } : {})
 		};

--- a/src/core/Task/TaskLifeCycle.ts
+++ b/src/core/Task/TaskLifeCycle.ts
@@ -1,4 +1,3 @@
-import { nextTick } from 'vue';
 import type { ObserveEmitter } from '../hooks/type';
 import type { InjectionConfig } from '../Injector/types';
 import { Logger } from '../logger/Logger';
@@ -51,8 +50,6 @@ export class TaskLifeCycle {
 			return;
 		}
 
-		const aliveEpoch = (context.aliveEpoch ?? 0) + 1;
-		context.aliveEpoch = aliveEpoch;
 		context.alive = true;
 		context.isObserver = false;
 		this.emit(
@@ -62,8 +59,7 @@ export class TaskLifeCycle {
 				kind: 'component',
 				injectAt: context.componentInjectAt,
 				status: context.taskStatus,
-				scope: context.scope,
-				aliveEpoch
+				scope: context.scope
 			})
 		);
 		// placeholder stop handler for pending async setup
@@ -82,53 +78,48 @@ export class TaskLifeCycle {
 			const currentDocument = matchedElement.ownerDocument || document;
 			const injectAt = context.componentInjectAt;
 
-			nextTick().then(() => {
-				if (!context.alive || context.aliveEpoch !== aliveEpoch) return;
-
-				const stopHandler = DOMWatcher.onDomAlive(
-					matchedElement,
-					injectAt,
-					() => {
-						this.taskContext.reset(taskId);
-					},
-					(el): void => this.onTargetReady(el, taskId),
-					context.scope === 'global' ? currentDocument : matchedElement,
-					{
-						once: true,
-						timeout: this.injectConfig.timeout
-					},
-					{
-						logger: this.logger,
-						emit: createDomObserveEmitFactory({
-							emit: this.emit,
-							taskId,
-							kind: 'component',
-							injectAt,
-							root: context.scope === 'global' ? currentDocument : matchedElement
-						})
-					}
-				);
-
-				if (!context.alive || context.aliveEpoch !== aliveEpoch) {
-					stopHandler();
-					return;
-				}
-				context.disableAlive = stopHandler;
-				context.isObserver = true;
-				this.emit(
-					'alive:observeStart',
-					buildAliveObservePayload('alive:observeStart', {
+			const stopHandler = DOMWatcher.onDomAlive(
+				matchedElement,
+				injectAt,
+				() => {
+					this.taskContext.reset(taskId);
+				},
+				(el): void => this.onTargetReady(el, taskId),
+				context.scope === 'global' ? currentDocument : matchedElement,
+				{
+					once: true,
+					timeout: this.injectConfig.timeout
+				},
+				{
+					logger: this.logger,
+					emit: createDomObserveEmitFactory({
+						emit: this.emit,
 						taskId,
 						kind: 'component',
 						injectAt,
-						status: context.taskStatus,
-						scope: context.scope,
-						aliveEpoch,
-						observerMode: 'mounted'
+						root: context.scope === 'global' ? currentDocument : matchedElement
 					})
-				);
-				this.logger.info(`Task "${taskId}" alive observer activated`);
-			});
+				}
+			);
+
+			if (!context.alive) {
+				stopHandler();
+				return;
+			}
+			context.disableAlive = stopHandler;
+			context.isObserver = true;
+			this.emit(
+				'alive:observeStart',
+				buildAliveObservePayload('alive:observeStart', {
+					taskId,
+					kind: 'component',
+					injectAt,
+					status: context.taskStatus,
+					scope: context.scope,
+					observerMode: 'mounted'
+				})
+			);
+			this.logger.info(`Task "${taskId}" alive observer activated`);
 			return;
 		}
 
@@ -146,9 +137,9 @@ export class TaskLifeCycle {
 			const stopReadyObserver = DOMWatcher.onDomReady(
 				context.componentInjectAt,
 				(el): void => {
-					if (cancelled || !context.alive || context.aliveEpoch !== aliveEpoch) {
+					if (cancelled || !context.alive) {
 						this.logger.warn(
-							`Task "${taskId}" alive epoch changed before element appears`
+							`Task "${taskId}" alive state changed before element appears`
 						);
 						return;
 					}
@@ -178,7 +169,6 @@ export class TaskLifeCycle {
 						injectAt: context.componentInjectAt,
 						status: context.taskStatus,
 						scope: context.scope,
-						aliveEpoch,
 						observerMode: 'await-target'
 					})
 				);
@@ -193,7 +183,6 @@ export class TaskLifeCycle {
 					injectAt: context.componentInjectAt,
 					status: context.taskStatus,
 					scope: context.scope,
-					aliveEpoch,
 					observerMode: 'await-target'
 				})
 			);
@@ -220,8 +209,6 @@ export class TaskLifeCycle {
 			return;
 		}
 
-		context.aliveEpoch = (context.aliveEpoch ?? 0) + 1;
-		const aliveEpoch = context.aliveEpoch;
 		const stopHandler = context.disableAlive;
 		context.alive = false;
 		context.isObserver = false;
@@ -234,8 +221,7 @@ export class TaskLifeCycle {
 				kind: 'component',
 				injectAt: context.componentInjectAt,
 				status: context.taskStatus,
-				scope: context.scope,
-				aliveEpoch
+				scope: context.scope
 			})
 		);
 		this.emit(
@@ -246,7 +232,6 @@ export class TaskLifeCycle {
 				injectAt: context.componentInjectAt,
 				status: context.taskStatus,
 				scope: context.scope,
-				aliveEpoch,
 				observerMode: context.app ? 'mounted' : 'await-target'
 			})
 		);

--- a/src/core/Task/TaskRegister.ts
+++ b/src/core/Task/TaskRegister.ts
@@ -185,7 +185,6 @@ export class TaskRegister {
 				withEvent: false,
 
 				alive,
-				aliveEpoch: 0,
 				scope,
 				timeout,
 				isObserver: false,

--- a/src/core/Task/TaskRunner.ts
+++ b/src/core/Task/TaskRunner.ts
@@ -1,5 +1,5 @@
 import type { App, ComponentPublicInstance, Plugin, WatchHandle, WatchSource } from 'vue';
-import { createApp, nextTick, watch } from 'vue';
+import { createApp, watch } from 'vue';
 import { UUID } from '../../util/uuid';
 import type { ObserveEmitter } from '../hooks/type';
 import { Action, type ActionEvent, type InjectionConfig } from '../Injector/types';
@@ -451,57 +451,40 @@ export class TaskRunner {
 			this.logger.info(`Component "${context.componentName}" injected at "${injectAt}"`);
 
 			if (context.alive && !context.isObserver) {
-				const aliveEpoch = context.aliveEpoch ?? 0;
 				// Injection re-injection mechanism
 				// if write 'global', the watcher will observer the document body element
 				// if write 'local', the watcher will observe the matchedElement, which is the component's host element
-				nextTick().then(() => {
-					// if changes happen during async setup, directly return
-					if (
-						!context.alive ||
-						context.aliveEpoch !== aliveEpoch ||
-						context.app !== subApp
-					)
-						return;
-
-					const stopHandler = DOMWatcher.onDomAlive(
-						matchedElement,
-						injectAt,
-						() => {
-							this.taskContext.reset(taskId);
-						},
-						(el): void => this.onTargetReady(el, taskId),
-						context.scope === 'global' ? currentDocument : matchedElement,
-						{
-							once: true,
-							timeout: this.injectConfig.timeout
-						},
-						{
-							logger: this.logger,
-							emit: createDomObserveEmitFactory({
-								emit: this.emit,
-								taskId,
-								kind: context.kind,
-								injectAt,
-								root: context.scope === 'global' ? currentDocument : matchedElement
-							})
-						}
-					);
-
-					// if changes happen during async setup,
-					// do not activate observer and clean up the listener
-					if (
-						!context.alive ||
-						context.aliveEpoch !== aliveEpoch ||
-						context.app !== subApp
-					) {
-						stopHandler();
-						return;
+				const stopHandler = DOMWatcher.onDomAlive(
+					matchedElement,
+					injectAt,
+					() => {
+						this.taskContext.reset(taskId);
+					},
+					(el): void => this.onTargetReady(el, taskId),
+					context.scope === 'global' ? currentDocument : matchedElement,
+					{
+						once: true,
+						timeout: this.injectConfig.timeout
+					},
+					{
+						logger: this.logger,
+						emit: createDomObserveEmitFactory({
+							emit: this.emit,
+							taskId,
+							kind: context.kind,
+							injectAt,
+							root: context.scope === 'global' ? currentDocument : matchedElement
+						})
 					}
+				);
+
+				if (!context.alive || context.app !== subApp) {
+					stopHandler();
+				} else {
 					context.disableAlive = stopHandler;
 					context.isObserver = true;
 					this.logger.info(`Task "${taskId}" alive observer activated`);
-				});
+				}
 			}
 
 			return {

--- a/src/core/Task/types.ts
+++ b/src/core/Task/types.ts
@@ -35,7 +35,6 @@ export interface ComponentTask extends BaseTask {
 	appRoot?: HTMLElement;
 	instance?: ComponentPublicInstance;
 
-	aliveEpoch?: number;
 	isObserver?: boolean;
 	disableAlive?: () => void;
 

--- a/src/core/payload/buildAliveObservePayload.ts
+++ b/src/core/payload/buildAliveObservePayload.ts
@@ -16,7 +16,6 @@ type AliveObserveBase = {
 	injectAt: string;
 	status: TaskStatus;
 	scope: 'local' | 'global';
-	aliveEpoch: number;
 };
 
 type AliveObserveInputByName = {
@@ -31,21 +30,18 @@ type AliveObservePayloadByName = {
 		kind: 'component';
 		meta: {
 			scope: 'local' | 'global';
-			aliveEpoch: number;
 		};
 	};
 	'alive:disable': Omit<ObserveEvent, 'name' | 'ts'> & {
 		kind: 'component';
 		meta: {
 			scope: 'local' | 'global';
-			aliveEpoch: number;
 		};
 	};
 	'alive:observeStart': Omit<ObserveEvent, 'name' | 'ts'> & {
 		kind: 'component';
 		meta: {
 			scope: 'local' | 'global';
-			aliveEpoch: number;
 			observerMode: AliveObserverMode;
 		};
 	};
@@ -53,7 +49,6 @@ type AliveObservePayloadByName = {
 		kind: 'component';
 		meta: {
 			scope: 'local' | 'global';
-			aliveEpoch: number;
 			observerMode: AliveObserverMode;
 		};
 	};
@@ -66,8 +61,7 @@ const aliveObservePayloadBuilders = {
 		injectAt: input.injectAt,
 		status: input.status,
 		meta: {
-			scope: input.scope,
-			aliveEpoch: input.aliveEpoch
+			scope: input.scope
 		}
 	}),
 	'alive:disable': (input) => ({
@@ -76,8 +70,7 @@ const aliveObservePayloadBuilders = {
 		injectAt: input.injectAt,
 		status: input.status,
 		meta: {
-			scope: input.scope,
-			aliveEpoch: input.aliveEpoch
+			scope: input.scope
 		}
 	}),
 	'alive:observeStart': (input) => ({
@@ -87,7 +80,6 @@ const aliveObservePayloadBuilders = {
 		status: input.status,
 		meta: {
 			scope: input.scope,
-			aliveEpoch: input.aliveEpoch,
 			observerMode: input.observerMode
 		}
 	}),
@@ -98,7 +90,6 @@ const aliveObservePayloadBuilders = {
 		status: input.status,
 		meta: {
 			scope: input.scope,
-			aliveEpoch: input.aliveEpoch,
 			observerMode: input.observerMode
 		}
 	})


### PR DESCRIPTION
This pull request focuses on simplifying the lifecycle event payloads and related test logic by removing the `aliveEpoch` property from both documentation and test cases. The changes ensure that the event payloads and tests only track the `alive` state and `scope`, making the codebase and documentation easier to understand and maintain.

**Documentation updates:**

* Removed `meta.aliveEpoch` from the payload descriptions for `alive:enable`, `alive:disable`, `alive:observeStart`, and `alive:observeStop` events in both `README.md` and `README.CN.md`, reflecting the streamlined event structure. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L364-R367) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L400-R400) [[3]](diffhunk://#diff-a1785f19d824b74f0d78693e120cd59fa15d6c59d277adca86b4cfc09c186497L365-R368) [[4]](diffhunk://#diff-a1785f19d824b74f0d78693e120cd59fa15d6c59d277adca86b4cfc09c186497L401-R401)

**Test simplification:**

* Updated `__test__/TaskLifeCycle.test.ts` to eliminate all usage and checks of the `aliveEpoch` property in test setup and assertions, and revised test logic to use only the `alive` state for tracking observer activity. Test descriptions and warning messages were also updated to reference the `alive` state instead of `aliveEpoch`. [[1]](diffhunk://#diff-e3caae7a791e103ad92e388d7cf79140e4dc3a3d54b609f6bc941204db7e6942L103) [[2]](diffhunk://#diff-e3caae7a791e103ad92e388d7cf79140e4dc3a3d54b609f6bc941204db7e6942L138) [[3]](diffhunk://#diff-e3caae7a791e103ad92e388d7cf79140e4dc3a3d54b609f6bc941204db7e6942L183) [[4]](diffhunk://#diff-e3caae7a791e103ad92e388d7cf79140e4dc3a3d54b609f6bc941204db7e6942L216-R224) [[5]](diffhunk://#diff-e3caae7a791e103ad92e388d7cf79140e4dc3a3d54b609f6bc941204db7e6942L249-R250) [[6]](diffhunk://#diff-e3caae7a791e103ad92e388d7cf79140e4dc3a3d54b609f6bc941204db7e6942L293) [[7]](diffhunk://#diff-e3caae7a791e103ad92e388d7cf79140e4dc3a3d54b609f6bc941204db7e6942L318) [[8]](diffhunk://#diff-e3caae7a791e103ad92e388d7cf79140e4dc3a3d54b609f6bc941204db7e6942L346) [[9]](diffhunk://#diff-e3caae7a791e103ad92e388d7cf79140e4dc3a3d54b609f6bc941204db7e6942L378) [[10]](diffhunk://#diff-e3caae7a791e103ad92e388d7cf79140e4dc3a3d54b609f6bc941204db7e6942L392-R372) [[11]](diffhunk://#diff-e3caae7a791e103ad92e388d7cf79140e4dc3a3d54b609f6bc941204db7e6942L416) [[12]](diffhunk://#diff-e3caae7a791e103ad92e388d7cf79140e4dc3a3d54b609f6bc941204db7e6942L439) [[13]](diffhunk://#diff-e3caae7a791e103ad92e388d7cf79140e4dc3a3d54b609f6bc941204db7e6942L451) [[14]](diffhunk://#diff-e3caae7a791e103ad92e388d7cf79140e4dc3a3d54b609f6bc941204db7e6942L618-L626) [[15]](diffhunk://#diff-e3caae7a791e103ad92e388d7cf79140e4dc3a3d54b609f6bc941204db7e6942L675) [[16]](diffhunk://#diff-e3caae7a791e103ad92e388d7cf79140e4dc3a3d54b609f6bc941204db7e6942L700-R667) [[17]](diffhunk://#diff-e3caae7a791e103ad92e388d7cf79140e4dc3a3d54b609f6bc941204db7e6942L718) [[18]](diffhunk://#diff-e3caae7a791e103ad92e388d7cf79140e4dc3a3d54b609f6bc941204db7e6942L730-R695) [[19]](diffhunk://#diff-e3caae7a791e103ad92e388d7cf79140e4dc3a3d54b609f6bc941204db7e6942L748)

* Updated test cases to remove unnecessary `nextTick` usage, making the tests synchronous and more straightforward. [[1]](diffhunk://#diff-e3caae7a791e103ad92e388d7cf79140e4dc3a3d54b609f6bc941204db7e6942L84-R84) [[2]](diffhunk://#diff-e3caae7a791e103ad92e388d7cf79140e4dc3a3d54b609f6bc941204db7e6942L112-R117) [[3]](diffhunk://#diff-e3caae7a791e103ad92e388d7cf79140e4dc3a3d54b609f6bc941204db7e6942L153) [[4]](diffhunk://#diff-e3caae7a791e103ad92e388d7cf79140e4dc3a3d54b609f6bc941204db7e6942L200-R197) [[5]](diffhunk://#diff-e3caae7a791e103ad92e388d7cf79140e4dc3a3d54b609f6bc941204db7e6942L582-R553) [[6]](diffhunk://#diff-e3caae7a791e103ad92e388d7cf79140e4dc3a3d54b609f6bc941204db7e6942L643-R612)

* Updated warning messages and test descriptions to clarify that checks are now based on the `alive` state rather than on a stale `aliveEpoch`. [[1]](diffhunk://#diff-e3caae7a791e103ad92e388d7cf79140e4dc3a3d54b609f6bc941204db7e6942L363-R343) [[2]](diffhunk://#diff-e3caae7a791e103ad92e388d7cf79140e4dc3a3d54b609f6bc941204db7e6942L392-R372)

These changes collectively reduce complexity and potential confusion around the observer lifecycle, making the codebase and documentation more maintainable and accessible.