### PR TITLE
feat:Add propagation control to ObserverHub

### DIFF
--- a/README.CN.md
+++ b/README.CN.md
@@ -316,15 +316,15 @@ import { Injector, ObserverHub } from 'vue-implant';
 const observer = new ObserverHub();
 const injector = new Injector({ observer });
 
-const offAny = observer.onAny((event) => {
+const offAny = observer.onAny((event, ctrl) => {
 	console.log('[observe]', event.name, event.taskId, event.injectAt, event.status);
 });
 
-const offFail = observer.on('inject:fail', (event) => {
+const offFail = observer.on('inject:fail', (event, ctrl) => {
 	console.error('inject failed:', event.taskId, event.error);
 });
 
-const offTask = observer.onTask('MyComp@#app', 'task:afterReset', (event) => {
+const offTask = observer.onTask('MyComp@#app', 'task:afterReset', (event, ctrl) => {
 	console.log('task reset completed:', event.taskId, event.preStatus, event.status);
 });
 
@@ -356,6 +356,35 @@ injector.register('#app', App, {
 - 全局钩子：在 `new Injector({ hooks })` 中配置，或通过 `injector.on(...)` / `injector.onAny(...)` 注册。
 - 组件级钩子：在 `injector.register(injectAt, component, { hooks })` 或`injector.onTask(taskId, event, hook)`中配置。
 - 当前组件级钩子仅支持 `register` 创建的组件任务，不支持 `registerListener`。
+
+### 传播控制
+
+每个钩子的第二个参数 `ctrl: PropagationCtrl` 可用于在单次 emit 周期中控制后续分发行为。
+
+| 方法 | 效果 |
+| --- | --- |
+| `ctrl.stopPropagation()` | 当前作用域内剩余钩子继续执行，但跳过后续作用域。 |
+| `ctrl.stopImmediatePropagation()` | 立即中断当前作用域内剩余钩子，并跳过所有后续作用域。 |
+
+单次 emit 的分发顺序：**任务作用域 → 事件作用域 → 全局（any）**
+
+```ts
+observer.onTask('MyComp@#app', 'inject:success', (event, ctrl) => {
+	console.log('任务层处理完成');
+	ctrl.stopPropagation(); // 事件层与全局层不再触发
+});
+
+observer.on('inject:success', (event) => {
+	// 上方任务层调用了 stopPropagation()，此处被跳过
+});
+
+observer.onAny((event) => {
+	// 同样被跳过
+});
+```
+
+> [!NOTE]
+> 只写一个参数的旧写法无需修改，`ctrl` 可直接忽略，运行时完全兼容。
 
 生命周期事件载荷：
 
@@ -621,6 +650,7 @@ injector.controlListener(taskId, Action.CLOSE);
 - 适配器相关：`MountAdapter`、`ResolvableMountAdapter`、`AdapterMountInput`、`AdapterMountResult`、`AdapterUnmountInput`、`AdapterUnmountReason`、`AdapterResolver`
 - Vue 挂载相关：`VueMountArtifact`、`VueMountHandle`、`VueMountInstance`
 - Signal 相关：`ActivitySignalSource`、`ActivitySignalSubscribable`、`SignalUnsubscribe`
+- Observer 相关：`PropagationCtrl`、`ObserveHook`、`ObserveEvent`、`ObserveEventName`
 
 
 

--- a/README.md
+++ b/README.md
@@ -314,15 +314,15 @@ import { Injector, ObserverHub } from 'vue-implant';
 const observer = new ObserverHub();
 const injector = new Injector({ observer });
 
-const offAny = observer.onAny((event) => {
+const offAny = observer.onAny((event, ctrl) => {
 	console.log('[observe]', event.name, event.taskId, event.injectAt, event.status);
 });
 
-const offFail = observer.on('inject:fail', (event) => {
+const offFail = observer.on('inject:fail', (event, ctrl) => {
 	console.error('inject failed:', event.taskId, event.error);
 });
 
-const offTask = observer.onTask('MyComp@#app', 'task:afterReset', (event) => {
+const offTask = observer.onTask('MyComp@#app', 'task:afterReset', (event, ctrl) => {
 	console.log('task reset completed:', event.taskId, event.preStatus, event.status);
 });
 
@@ -355,6 +355,35 @@ Hook scopes:
 - Task-scoped hooks: use `injector.onTask(taskId, event, hook)`.
 - Component-level hooks: pass `hooks` in `injector.register(injectAt, component, { hooks })`.
 - Current component-level hooks are only available for component tasks created by `register` (not `registerListener`).
+
+### Propagation Control
+
+Every hook receives a second argument `ctrl: PropagationCtrl`. Use it to stop further dispatch within a single emit cycle.
+
+| Method | Effect |
+| --- | --- |
+| `ctrl.stopPropagation()` | Remaining hooks in the current scope still run, but the next scope is skipped. |
+| `ctrl.stopImmediatePropagation()` | Stops all remaining hooks in the current scope and all subsequent scopes immediately. |
+
+Dispatch order per emit: **task-scoped → event-scoped → any**
+
+```ts
+observer.onTask('MyComp@#app', 'inject:success', (event, ctrl) => {
+	console.log('handled in task scope');
+	ctrl.stopPropagation(); // event-scoped and any hooks will not fire
+});
+
+observer.on('inject:success', (event) => {
+	// skipped when stopPropagation() was called by a task-scoped hook above
+});
+
+observer.onAny((event) => {
+	// also skipped
+});
+```
+
+> [!NOTE]
+> Hooks that do not use the second parameter continue to work without any modification. The `ctrl` argument can be safely ignored.
 
 Lifecycle event payloads:
 
@@ -620,6 +649,7 @@ The package also exposes advanced TypeScript types for integration and tooling:
 - Adapter-related: `MountAdapter`, `ResolvableMountAdapter`, `AdapterMountInput`, `AdapterMountResult`, `AdapterUnmountInput`, `AdapterUnmountReason`, `AdapterResolver`
 - Vue mount-related: `VueMountArtifact`, `VueMountHandle`, `VueMountInstance`
 - Signal-related: `ActivitySignalSource`, `ActivitySignalSubscribable`, `SignalUnsubscribe`
+- Observer-related: `PropagationCtrl`, `ObserveHook`, `ObserveEvent`, `ObserveEventName`
 
 ## Limitations ⚠️
 

--- a/__test__/Injector.test.ts
+++ b/__test__/Injector.test.ts
@@ -42,8 +42,8 @@ describe('Injector', () => {
 
 	it('should forward register to TaskRegister and wrap lifecycle callbacks', () => {
 		const registerSpy = vi.spyOn(taskRegister, 'register');
-		const enableSpy = vi.spyOn(taskLifeCycle, 'enableAlive').mockImplementation(() => { });
-		const disableSpy = vi.spyOn(taskLifeCycle, 'disableAlive').mockImplementation(() => { });
+		const enableSpy = vi.spyOn(taskLifeCycle, 'enableAlive').mockImplementation(() => {});
+		const disableSpy = vi.spyOn(taskLifeCycle, 'disableAlive').mockImplementation(() => {});
 		const component = createVueComponent('FacadeComp');
 
 		const result = injector.register('#app', component);
@@ -57,8 +57,8 @@ describe('Injector', () => {
 
 	it('should forward register to TaskRegister and wrap lifecycle callbacks', () => {
 		const registerSpy = vi.spyOn(taskRegister, 'register');
-		const enableSpy = vi.spyOn(taskLifeCycle, 'enableAlive').mockImplementation(() => { });
-		const disableSpy = vi.spyOn(taskLifeCycle, 'disableAlive').mockImplementation(() => { });
+		const enableSpy = vi.spyOn(taskLifeCycle, 'enableAlive').mockImplementation(() => {});
+		const disableSpy = vi.spyOn(taskLifeCycle, 'disableAlive').mockImplementation(() => {});
 		const artifact = createVueComponent('artifact');
 		const adapter = {
 			name: 'plain',
@@ -85,14 +85,14 @@ describe('Injector', () => {
 	});
 
 	it('should forward run to TaskRunner', () => {
-		const runSpy = vi.spyOn(taskRunner, 'run').mockImplementation(() => { });
+		const runSpy = vi.spyOn(taskRunner, 'run').mockImplementation(() => {});
 		injector.run();
 		expect(runSpy).toHaveBeenCalledOnce();
 	});
 
 	it('should forward enableAlive and disableAlive to TaskLifeCycle', () => {
-		const enableSpy = vi.spyOn(taskLifeCycle, 'enableAlive').mockImplementation(() => { });
-		const disableSpy = vi.spyOn(taskLifeCycle, 'disableAlive').mockImplementation(() => { });
+		const enableSpy = vi.spyOn(taskLifeCycle, 'enableAlive').mockImplementation(() => {});
+		const disableSpy = vi.spyOn(taskLifeCycle, 'disableAlive').mockImplementation(() => {});
 
 		injector.enableAlive('task-a');
 		injector.disableAlive('task-a');

--- a/__test__/ObserverHub.test.ts
+++ b/__test__/ObserverHub.test.ts
@@ -19,7 +19,13 @@ describe('ObserverHub', () => {
 		hub.emit(event);
 
 		expect(hook).toHaveBeenCalledOnce();
-		expect(hook).toHaveBeenCalledWith(event);
+		expect(hook).toHaveBeenCalledWith(
+			event,
+			expect.objectContaining({
+				stopImmediatePropagation: expect.any(Function),
+				stopPropagation: expect.any(Function)
+			})
+		);
 	});
 
 	it('should trigger onAny hooks for any event', () => {
@@ -51,6 +57,10 @@ describe('ObserverHub', () => {
 			expect.objectContaining({
 				name: 'run:start',
 				taskId: 'task-1'
+			}),
+			expect.objectContaining({
+				stopImmediatePropagation: expect.any(Function),
+				stopPropagation: expect.any(Function)
 			})
 		);
 		expect(task2Hook).not.toHaveBeenCalled();
@@ -71,6 +81,78 @@ describe('ObserverHub', () => {
 		expect(taskHook).toHaveBeenCalledOnce();
 		expect(scopedHook).toHaveBeenCalledOnce();
 		expect(anyHook).toHaveBeenCalledOnce();
+	});
+
+	it('should stop propagation from task hooks to scoped and any hooks', () => {
+		const hub = new ObserverHub();
+		const taskHook = vi.fn((_, ctrl) => {
+			ctrl.stopPropagation();
+		});
+		const nextTaskHook = vi.fn();
+		const scopedHook = vi.fn();
+		const anyHook = vi.fn();
+
+		hub.onTask('task-1', 'run:start', taskHook);
+		hub.onTask('task-1', 'run:start', nextTaskHook);
+		hub.on('run:start', scopedHook);
+		hub.onAny(anyHook);
+
+		hub.emitOnTask('task-1', {
+			name: 'run:start',
+			ts: Date.now()
+		});
+
+		expect(taskHook).toHaveBeenCalledOnce();
+		expect(nextTaskHook).toHaveBeenCalledOnce();
+		expect(scopedHook).not.toHaveBeenCalled();
+		expect(anyHook).not.toHaveBeenCalled();
+	});
+
+	it('should stop propagation from scoped hooks to any hooks', () => {
+		const hub = new ObserverHub();
+		const scopedHook = vi.fn((_, ctrl) => {
+			ctrl.stopPropagation();
+		});
+		const nextScopedHook = vi.fn();
+		const anyHook = vi.fn();
+
+		hub.on('run:start', scopedHook);
+		hub.on('run:start', nextScopedHook);
+		hub.onAny(anyHook);
+
+		hub.emit({
+			name: 'run:start',
+			ts: Date.now()
+		});
+
+		expect(scopedHook).toHaveBeenCalledOnce();
+		expect(nextScopedHook).toHaveBeenCalledOnce();
+		expect(anyHook).not.toHaveBeenCalled();
+	});
+
+	it('should stop immediate propagation within the current hook scope', () => {
+		const hub = new ObserverHub();
+		const taskHook = vi.fn((_, ctrl) => {
+			ctrl.stopImmediatePropagation();
+		});
+		const nextTaskHook = vi.fn();
+		const scopedHook = vi.fn();
+		const anyHook = vi.fn();
+
+		hub.onTask('task-1', 'run:start', taskHook);
+		hub.onTask('task-1', 'run:start', nextTaskHook);
+		hub.on('run:start', scopedHook);
+		hub.onAny(anyHook);
+
+		hub.emitOnTask('task-1', {
+			name: 'run:start',
+			ts: Date.now()
+		});
+
+		expect(taskHook).toHaveBeenCalledOnce();
+		expect(nextTaskHook).not.toHaveBeenCalled();
+		expect(scopedHook).not.toHaveBeenCalled();
+		expect(anyHook).not.toHaveBeenCalled();
 	});
 
 	it('should support unsubscribe from on()', () => {

--- a/__test__/TaskContext.test.ts
+++ b/__test__/TaskContext.test.ts
@@ -168,7 +168,7 @@ describe('TaskContext', () => {
 
 	describe('destroy', () => {
 		it('should delete context of none existing id correctly', () => {
-			const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => { });
+			const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 			taskContext.destroy('nonexistent');
 			expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('nonexistent'));
 		});
@@ -188,7 +188,7 @@ describe('TaskContext', () => {
 			expect(taskContext.taskErrorMessages).toHaveLength(0);
 		});
 		it('should destroy context of watcher correctly', () => {
-			const spy = vi.fn(() => { });
+			const spy = vi.fn(() => {});
 
 			const mockWatcher = spy as unknown as WatchHandle;
 
@@ -196,7 +196,7 @@ describe('TaskContext', () => {
 				taskId: 'test',
 				watcher: {
 					watcher: mockWatcher,
-					watchSource: { get: () => true, subscribe: () => () => { } }
+					watchSource: { get: () => true, subscribe: () => () => {} }
 				}
 			});
 
@@ -206,7 +206,7 @@ describe('TaskContext', () => {
 			expect(spy).toHaveBeenCalled();
 		});
 		it('should destroy context of listener correctly', () => {
-			const mockFn = vi.fn(() => { });
+			const mockFn = vi.fn(() => {});
 			const component = createVueComponent('Comp');
 			const context: Task = createArtifactTask({
 				taskId: 'test',
@@ -221,7 +221,7 @@ describe('TaskContext', () => {
 					listenAt: 'testListenAt',
 					event: 'click',
 					callback: () => undefined,
-					activitySignal: () => ({ get: () => true, subscribe: () => () => { } }),
+					activitySignal: () => ({ get: () => true, subscribe: () => () => {} }),
 					controller: {
 						abort: mockFn
 					} as unknown as AbortController
@@ -276,7 +276,7 @@ describe('TaskContext', () => {
 				timeout: 5000,
 				watcher: {
 					watcher: mockWatcher,
-					watchSource: { get: () => true, subscribe: () => () => { } }
+					watchSource: { get: () => true, subscribe: () => () => {} }
 				},
 				listenAt: 'testListenAt',
 				event: 'click',
@@ -346,7 +346,7 @@ describe('TaskContext', () => {
 				timeout: 5000,
 				watcher: {
 					watcher: mockWatcher1,
-					watchSource: { get: () => true, subscribe: () => () => { } }
+					watchSource: { get: () => true, subscribe: () => () => {} }
 				},
 				listenAt: 'testListenAt1',
 				event: 'click',
@@ -361,7 +361,7 @@ describe('TaskContext', () => {
 				timeout: 5000,
 				watcher: {
 					watcher: mockWatcher2,
-					watchSource: { get: () => true, subscribe: () => () => { } }
+					watchSource: { get: () => true, subscribe: () => () => {} }
 				},
 				listenAt: 'testListenAt2',
 				event: 'mouseover',
@@ -416,7 +416,7 @@ describe('TaskContext', () => {
 			});
 
 			taskContext.set('test', context);
-			const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => { });
+			const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
 			taskContext.releaseComponentInstance('test');
 
@@ -434,7 +434,7 @@ describe('TaskContext', () => {
 			});
 
 			taskContext.set('test', context);
-			const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => { });
+			const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
 			taskContext.releaseComponentInstance('test');
 
@@ -456,7 +456,7 @@ describe('TaskContext', () => {
 		});
 
 		it('should warn if context not found', () => {
-			const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => { });
+			const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 			taskContext.releaseDomElement('nonexistent');
 			expect(consoleWarnSpy).toHaveBeenCalledWith(
 				expect.stringContaining('Task "nonexistent" context not found')
@@ -466,7 +466,7 @@ describe('TaskContext', () => {
 		it('should warn if root element not found', () => {
 			const context: Task = createArtifactTask({ taskId: 'test' });
 			taskContext.set('test', context);
-			const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => { });
+			const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 			taskContext.releaseDomElement('test');
 			expect(consoleWarnSpy).toHaveBeenCalledWith(
 				expect.stringContaining('Root element for task "test" not found')
@@ -482,7 +482,7 @@ describe('TaskContext', () => {
 				appRoot: { remove: mockRemove } as unknown as HTMLElement
 			});
 			taskContext.set('test', context);
-			const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => { });
+			const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 			taskContext.releaseDomElement('test');
 			expect(mockRemove).toHaveBeenCalled();
 			expect(consoleErrorSpy).toHaveBeenCalledWith(
@@ -502,7 +502,7 @@ describe('TaskContext', () => {
 				event: 'click',
 				callback: () => undefined,
 				withEvent: true,
-				activitySignal: () => ({ get: () => true, subscribe: () => () => { } }),
+				activitySignal: () => ({ get: () => true, subscribe: () => () => {} }),
 				controller: { abort: mockAbort } as unknown as AbortController
 			});
 			taskContext.set('test', context);
@@ -512,7 +512,7 @@ describe('TaskContext', () => {
 			expect(context.withEvent).toBe(false);
 		});
 		it('should do nothing if context not found', () => {
-			const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => { });
+			const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 			taskContext.releaseListener('nonexistent');
 			expect(consoleErrorSpy).not.toHaveBeenCalled();
 		});
@@ -528,11 +528,11 @@ describe('TaskContext', () => {
 				event: 'click',
 				callback: () => undefined,
 				withEvent: true,
-				activitySignal: () => ({ get: () => true, subscribe: () => () => { } }),
+				activitySignal: () => ({ get: () => true, subscribe: () => () => {} }),
 				controller: { abort: mockAbort } as unknown as AbortController
 			});
 			taskContext.set('test', context);
-			const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => { });
+			const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 			taskContext.releaseListener('test');
 			expect(mockAbort).toHaveBeenCalled();
 			expect(consoleErrorSpy).toHaveBeenCalledWith(
@@ -550,10 +550,10 @@ describe('TaskContext', () => {
 				event: 'click',
 				callback: () => undefined,
 				withEvent: true,
-				activitySignal: () => ({ get: () => true, subscribe: () => () => { } })
+				activitySignal: () => ({ get: () => true, subscribe: () => () => {} })
 			});
 			taskContext.set('test', context);
-			const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => { });
+			const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 			taskContext.releaseListener('test');
 			expect(consoleErrorSpy).not.toHaveBeenCalled();
 		});
@@ -567,7 +567,7 @@ describe('TaskContext', () => {
 				artifact: component,
 				watcher: {
 					watcher: mockWatcher,
-					watchSource: { get: () => true, subscribe: () => () => { } }
+					watchSource: { get: () => true, subscribe: () => () => {} }
 				},
 				artifactName: 'TestComponent',
 				injectAt: '#app'
@@ -583,7 +583,7 @@ describe('TaskContext', () => {
 				taskId: 'test'
 			});
 			taskContext.set('test', context);
-			const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => { });
+			const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 			taskContext.releaseWatcher('test');
 			expect(consoleErrorSpy).not.toHaveBeenCalled();
 		});
@@ -597,11 +597,11 @@ describe('TaskContext', () => {
 				kind: 'component',
 				watcher: {
 					watcher: mockWatcher,
-					watchSource: { get: () => true, subscribe: () => () => { } }
+					watchSource: { get: () => true, subscribe: () => () => {} }
 				}
 			});
 			taskContext.set('test', context);
-			const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => { });
+			const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 			taskContext.releaseWatcher('test');
 			expect(mockWatcher).toHaveBeenCalled();
 			expect(consoleErrorSpy).toHaveBeenCalledWith(
@@ -625,7 +625,7 @@ describe('TaskContext', () => {
 				timeout: 5000,
 				watcher: {
 					watcher: mockWatcher,
-					watchSource: { get: () => true, subscribe: () => () => { } }
+					watchSource: { get: () => true, subscribe: () => () => {} }
 				},
 				listener: {
 					listenAt: 'testListenAt',
@@ -723,7 +723,7 @@ describe('TaskContext', () => {
 					appRoot: { remove: removeA } as unknown as HTMLElement,
 					watcher: {
 						watcher: watcherA,
-						watchSource: { get: () => true, subscribe: () => () => { } }
+						watchSource: { get: () => true, subscribe: () => () => {} }
 					},
 					isObserver: true
 				})
@@ -751,7 +751,7 @@ describe('TaskContext', () => {
 					appRoot: { remove: removeB } as unknown as HTMLElement,
 					watcher: {
 						watcher: watcherB,
-						watchSource: { get: () => true, subscribe: () => () => { } }
+						watchSource: { get: () => true, subscribe: () => () => {} }
 					},
 					isObserver: true
 				})
@@ -812,7 +812,7 @@ describe('TaskContext', () => {
 					scope: 'local',
 					watcher: {
 						watcher,
-						watchSource: { get: () => true, subscribe: () => () => { } }
+						watchSource: { get: () => true, subscribe: () => () => {} }
 					},
 					withEvent: true,
 					listener: {
@@ -868,7 +868,7 @@ describe('TaskContext', () => {
 					scope: 'local',
 					watcher: {
 						watcher,
-						watchSource: { get: () => true, subscribe: () => () => { } }
+						watchSource: { get: () => true, subscribe: () => () => {} }
 					},
 					withEvent: true,
 					listener: {

--- a/__test__/TaskLifeCycle.test.ts
+++ b/__test__/TaskLifeCycle.test.ts
@@ -36,13 +36,13 @@ describe('TaskLifeCycle', () => {
 	});
 
 	it('should warn for non-existent task on enableAlive', () => {
-		const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => { });
+		const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 		lifeCycle.enableAlive('missing');
 		expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Task "missing" not found'));
 	});
 
 	it('should warn for listener-only task on enableAlive', () => {
-		const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => { });
+		const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 		taskContext.set(
 			'listener-task',
 			createListenerTask({
@@ -61,7 +61,7 @@ describe('TaskLifeCycle', () => {
 	});
 
 	it('should warn when already observing on enableAlive', () => {
-		const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => { });
+		const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 		taskContext.set(
 			'already-alive',
 			createArtifactTask({
@@ -144,7 +144,7 @@ describe('TaskLifeCycle', () => {
 			.mockImplementation((_matchedElement, _injectAt, onRemove, onRestore) => {
 				onRemove();
 				onRestore(document.createElement('div'));
-				return () => { };
+				return () => {};
 			});
 
 		lifeCycle.enableAlive('mounted-callback-task');
@@ -181,8 +181,8 @@ describe('TaskLifeCycle', () => {
 			})
 		);
 
-		const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => { });
-		const aliveSpy = vi.spyOn(DOMWatcher, 'onDomAlive').mockReturnValue(() => { });
+		const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+		const aliveSpy = vi.spyOn(DOMWatcher, 'onDomAlive').mockReturnValue(() => {});
 
 		lifeCycle.enableAlive('shadow-task');
 
@@ -276,7 +276,7 @@ describe('TaskLifeCycle', () => {
 		);
 
 		const resetSpy = vi.spyOn(taskContext, 'reset');
-		const readySpy = vi.spyOn(DOMWatcher, 'onDomReady').mockReturnValue(() => { });
+		const readySpy = vi.spyOn(DOMWatcher, 'onDomReady').mockReturnValue(() => {});
 
 		lifeCycle.enableAlive('detached-task');
 
@@ -302,7 +302,7 @@ describe('TaskLifeCycle', () => {
 		const readySpy = vi.spyOn(DOMWatcher, 'onDomReady').mockImplementation((_, cb) => {
 			const el = document.createElement('div');
 			cb(el);
-			return () => { };
+			return () => {};
 		});
 
 		lifeCycle.enableAlive('case3-task');
@@ -329,9 +329,9 @@ describe('TaskLifeCycle', () => {
 		let readyCallback: ((el: HTMLElement) => void) | undefined;
 		vi.spyOn(DOMWatcher, 'onDomReady').mockImplementation((_selector, cb) => {
 			readyCallback = cb;
-			return () => { };
+			return () => {};
 		});
-		const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => { });
+		const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
 		lifeCycle.enableAlive('case3-cancelled-task');
 		taskContext.get<ArtifactTask>('case3-cancelled-task')?.disableAlive?.();
@@ -360,9 +360,9 @@ describe('TaskLifeCycle', () => {
 		let readyCallback: ((el: HTMLElement) => void) | undefined;
 		vi.spyOn(DOMWatcher, 'onDomReady').mockImplementation((_selector, cb) => {
 			readyCallback = cb;
-			return () => { };
+			return () => {};
 		});
-		const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => { });
+		const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
 		lifeCycle.enableAlive('case3-stale-task');
 		const context = taskContext.get<ArtifactTask>('case3-stale-task');
@@ -426,7 +426,7 @@ describe('TaskLifeCycle', () => {
 	});
 
 	it('should warn when disableAlive task is missing', () => {
-		const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => { });
+		const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 		lifeCycle.disableAlive('missing-disable-task');
 		expect(errorSpy).toHaveBeenCalledWith(
 			expect.stringContaining('Task "missing-disable-task" not found')
@@ -434,7 +434,7 @@ describe('TaskLifeCycle', () => {
 	});
 
 	it('should warn when disableAlive is called for task with alive=false', () => {
-		const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => { });
+		const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 		taskContext.set(
 			'not-alive-task',
 			createArtifactTask({
@@ -594,7 +594,7 @@ describe('TaskLifeCycle', () => {
 			})
 		);
 
-		vi.spyOn(DOMWatcher, 'onDomAlive').mockReturnValue(() => { });
+		vi.spyOn(DOMWatcher, 'onDomAlive').mockReturnValue(() => {});
 
 		lifecycleWithObserver.enableAlive('obs-life-task');
 		lifecycleWithObserver.disableAlive('obs-life-task');
@@ -650,7 +650,7 @@ describe('TaskLifeCycle', () => {
 			})
 		);
 
-		vi.spyOn(DOMWatcher, 'onDomAlive').mockReturnValue(() => { });
+		vi.spyOn(DOMWatcher, 'onDomAlive').mockReturnValue(() => {});
 
 		const aliveEvents: ObserveEvent[] = [];
 		observer.onAny((event) => {
@@ -747,7 +747,7 @@ describe('TaskLifeCycle', () => {
 			})
 		);
 
-		vi.spyOn(DOMWatcher, 'onDomReady').mockReturnValue(() => { });
+		vi.spyOn(DOMWatcher, 'onDomReady').mockReturnValue(() => {});
 
 		const aliveEvents: ObserveEvent[] = [];
 		observer.onAny((event) => {

--- a/__test__/TaskRegister.test.ts
+++ b/__test__/TaskRegister.test.ts
@@ -150,7 +150,7 @@ describe('TaskRegister', () => {
 	});
 
 	it('should return existing result for duplicate component registration', () => {
-		const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => { });
+		const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
 		const component = createVueComponent('CompDup');
 		const first = taskRegister.register('#dup', component);
@@ -189,7 +189,7 @@ describe('TaskRegister', () => {
 	});
 
 	it('should return existing result for duplicate listener registration', () => {
-		const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => { });
+		const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
 		const first = taskRegister.registerListener('#btn', 'click', vi.fn());
 		const second = taskRegister.registerListener('#btn', 'click', vi.fn());

--- a/__test__/TaskRunner.test.ts
+++ b/__test__/TaskRunner.test.ts
@@ -35,7 +35,7 @@ describe('TaskRunner', () => {
 			createObserveEmitter(observer)
 		);
 		document.body.innerHTML = '';
-		vi.spyOn(console, 'info').mockImplementation(() => { });
+		vi.spyOn(console, 'info').mockImplementation(() => {});
 	});
 
 	afterEach(() => {
@@ -95,7 +95,7 @@ describe('TaskRunner', () => {
 		taskContext.taskRecords.push({ taskId: 'run-pending-task', injectAt: '#run-pending' });
 		taskContext.taskRecords.push({ taskId: 'run-active-task', injectAt: '#run-active' });
 
-		vi.spyOn(DOMWatcher, 'onDomReady').mockReturnValue(() => { });
+		vi.spyOn(DOMWatcher, 'onDomReady').mockReturnValue(() => {});
 
 		const runEvents: ObserveEvent[] = [];
 		observer.onAny((event) => {
@@ -173,7 +173,7 @@ describe('TaskRunner', () => {
 		);
 		taskContext.taskRecords.push({ taskId: 'task-a', injectAt: '#app' });
 
-		const spy = vi.spyOn(DOMWatcher, 'onDomReady').mockReturnValue(() => { });
+		const spy = vi.spyOn(DOMWatcher, 'onDomReady').mockReturnValue(() => {});
 
 		taskRunner.run();
 
@@ -210,7 +210,7 @@ describe('TaskRunner', () => {
 		taskContext.taskRecords.push({ taskId: 'active-task', injectAt: '#a' });
 		taskContext.taskRecords.push({ taskId: 'pending-task', injectAt: '#b' });
 
-		const spy = vi.spyOn(DOMWatcher, 'onDomReady').mockReturnValue(() => { });
+		const spy = vi.spyOn(DOMWatcher, 'onDomReady').mockReturnValue(() => {});
 
 		taskRunner.run();
 
@@ -748,7 +748,7 @@ describe('TaskRunner', () => {
 	});
 
 	it('should warn and return false when attachEvent fails', () => {
-		const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => { });
+		const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 		const attachEventSpy = vi
 			.spyOn(
 				taskRunner as unknown as { attachEvent: (taskId: string) => void },
@@ -776,7 +776,7 @@ describe('TaskRunner', () => {
 	});
 
 	it('should warn on invalid action in controlListener', () => {
-		const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => { });
+		const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 		taskContext.set(
 			'invalid-action',
 			createListenerTask({
@@ -823,7 +823,7 @@ describe('TaskRunner', () => {
 	});
 
 	it('should keep task idle when target is detached on onTargetReady', () => {
-		const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => { });
+		const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 		const detached = document.createElement('div');
 
 		taskContext.set(
@@ -844,7 +844,7 @@ describe('TaskRunner', () => {
 	});
 
 	it('should warn and return when task is missing on onTargetReady', () => {
-		const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => { });
+		const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 		taskRunner.onTargetReady(document.createElement('div'), 'missing-task');
 		expect(errorSpy).toHaveBeenCalledWith(
 			expect.stringContaining('Task "missing-task" not found')
@@ -893,8 +893,11 @@ describe('TaskRunner', () => {
 	});
 
 	it('should return false when bindListenerSignal task is missing', () => {
-		const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => { });
-		const result = taskRunner.bindListenerSignal('missing-signal-task', createActivityStore(true));
+		const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+		const result = taskRunner.bindListenerSignal(
+			'missing-signal-task',
+			createActivityStore(true)
+		);
 		expect(result).toBe(false);
 		expect(errorSpy).toHaveBeenCalledWith(
 			expect.stringContaining('unable to bind activity signal')
@@ -916,7 +919,7 @@ describe('TaskRunner', () => {
 		vi.spyOn(taskRunner, 'controlListener').mockImplementation(() => {
 			throw new Error('watch failed');
 		});
-		const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => { });
+		const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
 		const result = taskRunner.bindListenerSignal('watch-error-task', createActivityStore(true));
 
@@ -928,7 +931,7 @@ describe('TaskRunner', () => {
 	});
 
 	it('should return false when task is missing in controlListener', () => {
-		const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => { });
+		const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 		const result = taskRunner.controlListener('missing-listener-task', Action.OPEN);
 		expect(result).toBe(false);
 		expect(errorSpy).toHaveBeenCalledWith(
@@ -937,7 +940,7 @@ describe('TaskRunner', () => {
 	});
 
 	it('should return false when event binding config is incomplete in controlListener', () => {
-		const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => { });
+		const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 		taskContext.set(
 			'incomplete-listener-task',
 			createListenerTask({
@@ -995,7 +998,7 @@ describe('TaskRunner', () => {
 		const readySpy = vi.spyOn(DOMWatcher, 'onDomReady').mockImplementation((_, cb) => {
 			const el = document.createElement('button');
 			cb(el);
-			return () => { };
+			return () => {};
 		});
 		taskContext.set(
 			'fallback-open-task',
@@ -1019,7 +1022,7 @@ describe('TaskRunner', () => {
 	it('should set task idle when component taskId field is empty in onTargetReady', () => {
 		const host = document.createElement('div');
 		document.body.appendChild(host);
-		const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => { });
+		const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
 		taskContext.set(
 			'broken-task-key',
@@ -1042,7 +1045,7 @@ describe('TaskRunner', () => {
 	it('should set task idle when component mount throws in onTargetReady', () => {
 		const host = document.createElement('div');
 		document.body.appendChild(host);
-		const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => { });
+		const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
 		taskContext.set(
 			'mount-error-task',
@@ -1073,7 +1076,7 @@ describe('TaskRunner', () => {
 		host.id = 'global-alive-host';
 		document.body.appendChild(host);
 
-		const aliveSpy = vi.spyOn(DOMWatcher, 'onDomAlive').mockReturnValue(() => { });
+		const aliveSpy = vi.spyOn(DOMWatcher, 'onDomAlive').mockReturnValue(() => {});
 		taskContext.set(
 			'global-alive-task',
 			createArtifactTask({
@@ -1185,7 +1188,7 @@ describe('TaskRunner', () => {
 					ctx.alive = false;
 				}
 				onRestore(document.createElement('div'));
-				return () => { };
+				return () => {};
 			}
 		);
 

--- a/__test__/observeActivitySignal.test.ts
+++ b/__test__/observeActivitySignal.test.ts
@@ -29,7 +29,7 @@ describe('observeActivitySignal', () => {
 		const listener = vi.fn();
 		const source = {
 			get: () => true,
-			subscribe: vi.fn(() => () => { })
+			subscribe: vi.fn(() => () => {})
 		};
 
 		const unsubscribe = observeActivitySignal(source, listener);

--- a/src/core/Task/TaskRunner.ts
+++ b/src/core/Task/TaskRunner.ts
@@ -230,12 +230,9 @@ export class TaskRunner {
 		}
 
 		try {
-			const unWatch = observeActivitySignal(
-				source,
-				(newSignal) => {
-					this.controlListener(taskId, newSignal ? Action.OPEN : Action.CLOSE);
-				}
-			);
+			const unWatch = observeActivitySignal(source, (newSignal) => {
+				this.controlListener(taskId, newSignal ? Action.OPEN : Action.CLOSE);
+			});
 
 			context.watcher = {
 				watcher: unWatch,

--- a/src/core/hooks/ObserverHub.ts
+++ b/src/core/hooks/ObserverHub.ts
@@ -1,6 +1,13 @@
 import { Logger } from '../logger/Logger';
 import type { ILogger } from '../logger/types';
-import type { ObserveEvent, ObserveEventName, ObserveHook } from './type';
+import type {
+	ObserveEvent,
+	ObserveEventName,
+	ObserveHook,
+	PropagationCtrl,
+	PropagationState
+} from './type';
+import { createPropagationState } from './util';
 
 export class ObserverHub {
 	private eventHooks: Map<ObserveEventName, Set<ObserveHook>> = new Map();
@@ -140,8 +147,11 @@ export class ObserverHub {
 			this.emitOnTask(event.taskId, event);
 			return;
 		}
-		this.dispatchHooks(this.eventHooks.get(event.name), event);
-		this.dispatchHooks(this.anyHooks, event);
+
+		const propagation = createPropagationState();
+		this.dispatchHooks(this.eventHooks.get(event.name), event, propagation);
+		if (propagation.isPropagationStopped()) return;
+		this.dispatchHooks(this.anyHooks, event, propagation);
 	}
 
 	public emitOnTask(taskId: string, event: ObserveEvent): void {
@@ -154,21 +164,29 @@ export class ObserverHub {
 
 		if (!hasTaskScopedHooks && !hasScopedHooks && this.anyHooks.size === 0) return;
 
-		this.dispatchHooks(taskScoped, normalized);
-		this.dispatchHooks(scoped, normalized);
-		this.dispatchHooks(this.anyHooks, normalized);
+		const propagation = createPropagationState();
+		this.dispatchHooks(taskScoped, normalized, propagation);
+		if (propagation.isPropagationStopped()) return;
+		this.dispatchHooks(scoped, normalized, propagation);
+		if (propagation.isPropagationStopped()) return;
+		this.dispatchHooks(this.anyHooks, normalized, propagation);
 	}
 
-	private dispatchHooks(hooks: Set<ObserveHook> | undefined, event: ObserveEvent): void {
+	private dispatchHooks(
+		hooks: Set<ObserveHook> | undefined,
+		event: ObserveEvent,
+		propagation: PropagationState
+	): void {
 		if (!hooks || hooks.size === 0) return;
 		for (const hook of [...hooks]) {
-			this.callSafely(hook, event);
+			if (propagation.isImmediatePropagationStopped()) return;
+			this.callSafely(hook, event, propagation.ctrl);
 		}
 	}
 
-	private callSafely(hook: ObserveHook, event: ObserveEvent): void {
+	private callSafely(hook: ObserveHook, event: ObserveEvent, ctrl: PropagationCtrl): void {
 		try {
-			hook(event);
+			hook(event, ctrl);
 		} catch (error) {
 			this.logger.error(`Hook execution failed for event "${event.name}".`, error);
 		}

--- a/src/core/hooks/type.ts
+++ b/src/core/hooks/type.ts
@@ -44,11 +44,19 @@ export type ObserveEvent = {
 	durationMs?: number;
 	error?: unknown;
 	preStatus?: TaskStatus;
-	nextStatus?: TaskStatus;
 	meta?: Record<string, unknown>;
 };
+export type PropagationState = {
+	ctrl: PropagationCtrl;
+	isPropagationStopped(): boolean;
+	isImmediatePropagationStopped(): boolean;
+};
 
-export type ObserveHook = (event: ObserveEvent) => void;
+export type PropagationCtrl = {
+	stopPropagation(): void;
+	stopImmediatePropagation(): void;
+};
+export type ObserveHook = (event: ObserveEvent, ctrl: PropagationCtrl) => void;
 
 export type LifecycleHookMap = Partial<Record<ObserveEventName, ObserveHook | ObserveHook[]>>;
 

--- a/src/core/hooks/util.ts
+++ b/src/core/hooks/util.ts
@@ -1,5 +1,11 @@
 import type { ObserverHub } from './ObserverHub';
-import type { LifecycleHookMap, ObserveEmitter, ObserveEventName, ObserveHook } from './type';
+import type {
+	LifecycleHookMap,
+	ObserveEmitter,
+	ObserveEventName,
+	ObserveHook,
+	PropagationState
+} from './type';
 
 export const noopObserveEmitter: ObserveEmitter = () => {};
 
@@ -37,4 +43,26 @@ export function registerHooks(
 			}
 		}
 	}
+}
+export function createPropagationState(): PropagationState {
+	let stopped = false;
+	let immediateStopped = false;
+
+	return {
+		ctrl: {
+			stopPropagation() {
+				stopped = true;
+			},
+			stopImmediatePropagation() {
+				stopped = true;
+				immediateStopped = true;
+			}
+		},
+		isPropagationStopped() {
+			return stopped;
+		},
+		isImmediatePropagationStopped() {
+			return immediateStopped;
+		}
+	};
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,4 +39,4 @@ export type {
 	SignalUnsubscribe
 } from './core/signal/types';
 export type { ListenerRegisterResult, RegisterResult } from './core/Task/types';
-export { Action, VuePlugin, DOMWatcher, Injector, ObserverHub, createActivityStore };
+export { Action, createActivityStore, DOMWatcher, Injector, ObserverHub, VuePlugin };


### PR DESCRIPTION
This pull request introduces a propagation control mechanism for observer hooks, allowing fine-grained control over event hook execution order and cancellation. It updates the hook signatures to include a control object, adds comprehensive documentation and tests, and exposes new types for integration.

**Propagation control for observer hooks:**

* Added a `PropagationCtrl` argument to all observer hooks, enabling hooks to call `stopPropagation()` or `stopImmediatePropagation()` to control event propagation across task, event, and global scopes. (`src/core/hooks/type.ts`, `src/core/hooks/ObserverHub.ts`, `src/core/hooks/util.ts`, `README.md`, `README.CN.md`) [[1]](diffhunk://#diff-e3f29ebc7e41924a73c60963559b3a22b778c92f1f93026d833116320f53e9fbL3-R10) [[2]](diffhunk://#diff-e3f29ebc7e41924a73c60963559b3a22b778c92f1f93026d833116320f53e9fbL143-R154) [[3]](diffhunk://#diff-e3f29ebc7e41924a73c60963559b3a22b778c92f1f93026d833116320f53e9fbL157-R189) [[4]](diffhunk://#diff-4108bec495249b3df17d02520ba90a9a5f758a336b9474e92f96bd658bde0972L47-R59) [[5]](diffhunk://#diff-053e08de94624c723aa678533ec949cd08843796f6ae0c29a55c5c49bf096d69R47-R68) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L317-R325) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R359-R387) [[8]](diffhunk://#diff-a1785f19d824b74f0d78693e120cd59fa15d6c59d277adca86b4cfc09c186497L319-R327) [[9]](diffhunk://#diff-a1785f19d824b74f0d78693e120cd59fa15d6c59d277adca86b4cfc09c186497R360-R388)
* Updated all hook invocations and tests to use the new two-argument signature, ensuring backward compatibility if the second argument is omitted. (`src/core/hooks/ObserverHub.ts`, `__test__/ObserverHub.test.ts`) [[1]](diffhunk://#diff-e3f29ebc7e41924a73c60963559b3a22b778c92f1f93026d833116320f53e9fbL157-R189) [[2]](diffhunk://#diff-8e371239fae25c3c8affe4c4fa305016b1ca5bf2adb0e328ade5c464fae2bb79L22-R28) [[3]](diffhunk://#diff-8e371239fae25c3c8affe4c4fa305016b1ca5bf2adb0e328ade5c464fae2bb79R60-R63) [[4]](diffhunk://#diff-8e371239fae25c3c8affe4c4fa305016b1ca5bf2adb0e328ade5c464fae2bb79R86-R157)

**Documentation and type exports:**

* Documented the propagation control feature, including usage examples and migration notes, in both English and Chinese README files. (`README.md`, `README.CN.md`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R359-R387) [[2]](diffhunk://#diff-a1785f19d824b74f0d78693e120cd59fa15d6c59d277adca86b4cfc09c186497R360-R388)
* Exported new observer-related types (`PropagationCtrl`, `ObserveHook`, `ObserveEvent`, `ObserveEventName`) for integration and tooling. (`src/index.ts`, `README.md`, `README.CN.md`) [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L42-R42) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R652) [[3]](diffhunk://#diff-a1785f19d824b74f0d78693e120cd59fa15d6c59d277adca86b4cfc09c186497R653)

**Other minor improvements:**

* Refactored code for clarity and consistency, including argument formatting and export order. (`src/core/Task/TaskRunner.ts`, `src/index.ts`) [[1]](diffhunk://#diff-0896c036e8a2cbb58bfc98c65dc137c51aa2108448da1c74aa928412eed36525L233-R235) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L42-R42)
* Added and updated tests to cover new propagation behaviors and edge cases. (`__test__/ObserverHub.test.ts`)

These changes provide more control and flexibility for event handling in the observer system, improve documentation for users, and ensure robust type support for TypeScript consumers.