### PR TITLE
fix:local debug cause the problem that find local package`s package.json

### DIFF
--- a/.github/workflows/patch-release.yml
+++ b/.github/workflows/patch-release.yml
@@ -173,8 +173,14 @@ jobs:
         if: steps.versions.outputs.should_release == 'true'
         run: pnpm test
 
-      - name: Create and push tag
+      - name: Skip automated release while initial publishing is manual
         if: steps.versions.outputs.should_release == 'true'
+        run: |
+          echo "Patch bump detected for: ${{ steps.versions.outputs.packages }}"
+          echo "Automated tag, GitHub Release, and npm publish are temporarily disabled."
+
+      - name: Create and push tag
+        if: false
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -193,7 +199,7 @@ jobs:
           fi
 
       - name: Create or update GitHub Release
-        if: steps.versions.outputs.should_release == 'true'
+        if: false
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
@@ -208,7 +214,7 @@ jobs:
           fi
 
       - name: Publish to npm
-        if: steps.versions.outputs.should_release == 'true'
+        if: false
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         shell: bash

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.4.6/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
 	"vcs": {
 		"enabled": true,
 		"clientKind": "git",

--- a/packages/create-makoo/package.json
+++ b/packages/create-makoo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@makoojs/create-makoo",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Scaffold Makoo userscript development framework projects",
   "type": "module",
   "license": "MIT",

--- a/packages/create-makoo/src/template/makooVersion.ts
+++ b/packages/create-makoo/src/template/makooVersion.ts
@@ -1,0 +1,6 @@
+export const recommendedMakooVersions = {
+	core: '^0.1.0',
+	cli: '^0.1.0',
+	vue: '^0.1.0',
+	react: '^0.1.0'
+} as const satisfies Record<string, string>;

--- a/packages/create-makoo/src/template/util.ts
+++ b/packages/create-makoo/src/template/util.ts
@@ -1,6 +1,7 @@
-import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { copyFileSync, existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { recommendedMakooVersions } from './makooVersion';
 import type {
 	DependencyMode,
 	MakooDependencyResult,
@@ -47,6 +48,7 @@ export const ansi = {
 export const colorize = (value: string, ...codes: string[]): string => {
 	return `${codes.join('')}${value}${ansi.reset}`;
 };
+
 function ensureDir(dir: string): void {
 	if (!existsSync(dir)) {
 		mkdirSync(dir, { recursive: true });
@@ -55,11 +57,6 @@ function ensureDir(dir: string): void {
 
 function toJson(value: unknown): string {
 	return `${JSON.stringify(value, null, 2)}\n`;
-}
-
-function readJsonFile<T>(filePath: string): T {
-	const content = readFileSync(filePath, 'utf-8').replace(/^\uFEFF/, '');
-	return JSON.parse(content) as T;
 }
 
 function resolveAssetRoot(): string {
@@ -91,13 +88,6 @@ function resolveRepoRoot(): string {
 	}
 
 	throw new Error('[makoo] Repository root not found.');
-}
-
-function resolveMakooVersion(packageName: string): string {
-	const packageJsonPath = join(resolveRepoRoot(), 'packages', packageName, 'package.json');
-	const packageJson = readJsonFile<{ version: string }>(packageJsonPath);
-
-	return `^${packageJson.version}`;
 }
 
 function resolveLocalPackagePath(packageName: string): string {
@@ -141,7 +131,9 @@ export function resolveMakooDependencies(
 	mode: DependencyMode
 ): MakooDependencyResult {
 	const packagePath = (name: string): string =>
-		mode === 'local' ? resolveLocalPackagePath(name) : resolveMakooVersion(name);
+		mode === 'local'
+			? resolveLocalPackagePath(name)
+			: recommendedMakooVersions[name as keyof typeof recommendedMakooVersions];
 
 	return {
 		dependencies: {

--- a/packages/create-makoo/test/util.test.ts
+++ b/packages/create-makoo/test/util.test.ts
@@ -13,7 +13,7 @@ describe('resolveDependencyMode', () => {
 });
 
 describe('resolveMakooDependencies', () => {
-	it('returns npm package versions in npm mode', () => {
+	it('returns recommended package versions in npm mode', () => {
 		const result = resolveMakooDependencies('Vue', 'npm');
 
 		expect(result.dependencies['@makoojs/core']).toBe('^0.1.0');

--- a/packages/create-makoo/test/vue-template.test.ts
+++ b/packages/create-makoo/test/vue-template.test.ts
@@ -86,6 +86,19 @@ describe('generateVueTemplate', () => {
 		});
 	});
 
+	it('uses recommended Makoo versions for npm dependencies', async () => {
+		const root = await trackProject({});
+
+		await withCwd(root, async () => {
+			generateVueTemplate(createInitData('ts'));
+
+			const packageJsonPath = path.join(root, 'demo-app', 'package.json');
+			expect(readFileSync(packageJsonPath, 'utf-8')).toContain('"@makoojs/core": "^0.1.0"');
+			expect(readFileSync(packageJsonPath, 'utf-8')).toContain('"@makoojs/vue": "^0.1.0"');
+			expect(readFileSync(packageJsonPath, 'utf-8')).toContain('"@makoojs/cli": "^0.1.0"');
+		});
+	});
+
 	it('adds local resolve dedupe for Vue debug projects', async () => {
 		const root = await trackProject({});
 


### PR DESCRIPTION
This pull request introduces several changes to the `@makoojs/create-makoo` package and its release workflow. The main focus is on improving dependency version management by introducing a centralized source for recommended package versions, updating tests to reflect this, and temporarily disabling automated release steps in the CI workflow.

Dependency version management improvements:

* Introduced `recommendedMakooVersions` in `makooVersion.ts` to centralize and standardize the recommended versions for core Makoo packages. (`packages/create-makoo/src/template/makooVersion.ts` [packages/create-makoo/src/template/makooVersion.tsR1-R6](diffhunk://#diff-6dbad2e164b073f32afc208d7ec7ac533951da994922b99d5cad32eb94ff2d1cR1-R6))
* Refactored `resolveMakooDependencies` in `util.ts` to use `recommendedMakooVersions` for npm dependencies instead of reading local package versions, simplifying version management. (`packages/create-makoo/src/template/util.ts` [[1]](diffhunk://#diff-f52fc4bcd9db3e550c1a4319fda245ce6037496f5cce42a04d7f661840e715e8L96-L102) [[2]](diffhunk://#diff-f52fc4bcd9db3e550c1a4319fda245ce6037496f5cce42a04d7f661840e715e8L144-R136)
* Updated tests to expect recommended versions from `recommendedMakooVersions`, ensuring test accuracy and alignment with the new logic. (`packages/create-makoo/test/util.test.ts` [[1]](diffhunk://#diff-0b4f2ecc3f123d00e0b4336d6046328ba1276806b3334893e9a43625dd8cb17aL16-R16) `packages/create-makoo/test/vue-template.test.ts` [[2]](diffhunk://#diff-240e4082a9445b2e236b34277479b28345f499ad61d89744653afa7411a9bae0R89-R101)

Release workflow changes:

* Temporarily disabled automated tagging, GitHub Release creation, and npm publishing in the patch release workflow to support manual publishing during the initial release phase. (`.github/workflows/patch-release.yml` [[1]](diffhunk://#diff-72629bd5465e70b44ee7d125d0d60381a28e53a10e3bcfbe49c4c32c035da99dL176-R183) [[2]](diffhunk://#diff-72629bd5465e70b44ee7d125d0d60381a28e53a10e3bcfbe49c4c32c035da99dL196-R202) [[3]](diffhunk://#diff-72629bd5465e70b44ee7d125d0d60381a28e53a10e3bcfbe49c4c32c035da99dL211-R217)

Other updates:

* Updated the Biome schema version in `biome.json` to the latest, ensuring up-to-date linting and formatting. (`biome.json` [biome.jsonL2-R2](diffhunk://#diff-2bc8a1f5e9380d5a187a4e90f11b4dd36c3abad6aea44c84be354a4f44cdec55L2-R2))
* Bumped the package version of `@makoojs/create-makoo` from `0.1.0` to `0.1.1`. (`packages/create-makoo/package.json` [packages/create-makoo/package.jsonL3-R3](diffhunk://#diff-9c23c1b4ae75a22d5ce88430e0fc4190b267a3a6f5a9b45fa21d574d2cbff5aaL3-R3))