### PR TITLE
Refactor/task id generator rule

### DIFF
--- a/.changeset/few-bags-carry.md
+++ b/.changeset/few-bags-carry.md
@@ -1,0 +1,36 @@
+---
+"@makoojs/core": patch
+"@makoojs/cli": patch
+---
+
+Patch Changes
+
+✨ New Object-Form Injection API
+
+`@makoojs/core` now supports object-form `inject()` declarations.
+
+You can continue using the existing positional form: `inject('#toolbar', Toolbar, options)`.
+
+Or use the new object form when you want to keep declaration fields together or provide a stable task id: `inject({ id: 'toolbar', injectAt: '#toolbar', artifact: Toolbar, options })`.
+
+The optional `id` is used as the task id, making later task lookup and control easier through APIs such as `started.get(...)`, `reset(...)`, and `destroy(...)`.
+
+🐛 Safer Inferred Injection Task IDs
+
+Core now avoids false duplicate detection when different artifacts share the same artifact name and target selector.
+
+Previously, two different components with the same name, such as multiple `App.vue` files injected into `body`, could resolve to the same inferred task id and cause the second task to be skipped as a duplicate.
+
+Makoo now keeps duplicate skipping for the same artifact reference, while assigning fallback task ids when different artifacts would otherwise collide.
+
+Patch Changes
+
+🔧 CLI Uses Module IDs As Injection Task IDs
+
+`@makoojs/cli` now generates object-form `inject()` declarations and passes each resolved module id as the task id.
+
+This makes generated runtime tasks stable and prevents same-named components from colliding at runtime, for example `inject({ id: 'profile-panel', injectAt: 'body', artifact: Injection_profile_panel, options })`.
+
+📚 Documentation
+
+Updated the core README and docs website API pages to show both `inject()` forms and explain when the object form is useful.

--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,4 @@ dist-ssr
 *.sw?
 .pnpm-store
 .tmp
-docs
+/docs/

--- a/apps/docs-website/docs/api/core.md
+++ b/apps/docs-website/docs/api/core.md
@@ -78,6 +78,29 @@ makoo.start([
 
 `inject()` and `listen()` are declaration helpers. They do not touch the DOM and do not register tasks by themselves. `makoo.start([...])` registers the declarations in the provided batch and immediately schedules those tasks.
 
+`inject()` has two forms. The positional form is concise:
+
+```ts
+inject('#toolbar', toolbarArtifact, {
+	alive: true
+});
+```
+
+The object form keeps the declaration fields together. Its optional `id` is used as the task id, which is useful when you want to look up or control that task later:
+
+```ts
+inject({
+	id: 'settings-panel',
+	injectAt: '#settings',
+	artifact: settingsArtifact,
+	options: {
+		alive: true
+	}
+});
+```
+
+When `id` is omitted, Makoo infers a task id from the artifact and target selector.
+
 ```ts
 import { createMakoo, inject, listen } from '@makoojs/core';
 
@@ -97,7 +120,17 @@ const makoo = createMakoo({
 
 const started = makoo.start([
 	inject('#toolbar', toolbarArtifact, {
-		alive: true,
+		alive: true
+	}),
+	inject({
+		id: 'settings-panel',
+		injectAt: '#settings',
+		artifact: settingsArtifact,
+		options: {
+			alive: true
+		}
+	}),
+	inject('#save-tip', saveTipArtifact, {
 		on: listen('#save', 'click', () => {
 			console.log('save clicked');
 		})

--- a/apps/docs-website/docs/zh/api/core.md
+++ b/apps/docs-website/docs/zh/api/core.md
@@ -78,6 +78,29 @@ makoo.start([
 
 `inject()` 和 `listen()` 是声明 helper。它们不会触碰 DOM，也不会自己注册任务。`makoo.start([...])` 会注册传入批次里的声明，并立即调度这些任务。
 
+`inject()` 有两种写法。参数形式比较简洁：
+
+```ts
+inject('#toolbar', toolbarArtifact, {
+	alive: true
+});
+```
+
+对象形式会把声明字段放在一起。里面可选的 `id` 会作为任务 ID，适合后续需要查找或控制这个任务的场景：
+
+```ts
+inject({
+	id: 'settings-panel',
+	injectAt: '#settings',
+	artifact: settingsArtifact,
+	options: {
+		alive: true
+	}
+});
+```
+
+没有传 `id` 时，Makoo 会根据 artifact 和目标 selector 推导任务 ID。
+
 ```ts
 import { createMakoo, inject, listen } from '@makoojs/core';
 
@@ -97,7 +120,17 @@ const makoo = createMakoo({
 
 const started = makoo.start([
 	inject('#toolbar', toolbarArtifact, {
-		alive: true,
+		alive: true
+	}),
+	inject({
+		id: 'settings-panel',
+		injectAt: '#settings',
+		artifact: settingsArtifact,
+		options: {
+			alive: true
+		}
+	}),
+	inject('#save-tip', saveTipArtifact, {
 		on: listen('#save', 'click', () => {
 			console.log('save clicked');
 		})

--- a/packages/cli/src/generator/render/init/registerComp.ts
+++ b/packages/cli/src/generator/render/init/registerComp.ts
@@ -34,7 +34,13 @@ export function renderRegisterComponent(
 			hooks: item.componentMeta.hooks
 		};
 		const options = renderArtifactOptions(config, item.componentMeta.on);
-		const register = `${instanceName}Tasks.push(inject(${JSON.stringify(item.componentMeta.injectAt)}, ${item.componentName}, ${options}));`;
+		const declaration = [
+			`"id":${JSON.stringify(item.componentMeta.moduleId)}`,
+			`"injectAt":${JSON.stringify(item.componentMeta.injectAt)}`,
+			`"artifact":${item.componentName}`,
+			`"options":${options}`
+		].join(',');
+		const register = `${instanceName}Tasks.push(inject({${declaration}}));`;
 
 		if (!item.componentMeta.match) {
 			return register;

--- a/packages/cli/test/generator.test.ts
+++ b/packages/cli/test/generator.test.ts
@@ -77,7 +77,9 @@ describe('generate', () => {
 		expect(result.code).toContain('"start:requested":(() => "run-start")');
 		expect(result.code).toContain('adapters: [createReactAdapter()]');
 		expect(result.code).toContain('const makooTasks = [];');
-		expect(result.code).toContain('makooTasks.push(inject("#app", Injection_hello_card,');
+		expect(result.code).toContain(
+			'makooTasks.push(inject({"id":"hello-card","injectAt":"#app","artifact":Injection_hello_card,"options":'
+		);
 		expect(result.code).toContain('listen("#app", "click", (() => "clicked"))');
 		expect(result.code).toContain('makoo.start(makooTasks)');
 	});
@@ -142,8 +144,72 @@ describe('generate', () => {
 		expect(result.code).toContain(
 			'if (matchUrl(location.href, {"include":["https://example.com/*"],"exclude":["https://example.com/admin/*"]})) {'
 		);
-		expect(result.code).toContain('makooTasks.push(inject("#app", Injection_matched_card,');
-		expect(result.code).toContain('makooTasks.push(inject("#plain", Injection_plain_card,');
+		expect(result.code).toContain(
+			'makooTasks.push(inject({"id":"matched-card","injectAt":"#app","artifact":Injection_matched_card,"options":'
+		);
+		expect(result.code).toContain(
+			'makooTasks.push(inject({"id":"plain-card","injectAt":"#plain","artifact":Injection_plain_card,"options":'
+		);
+	});
+
+	it('uses module ids as generated object-form injection ids for same-named components', () => {
+		const config = resolveConfig(
+			{
+				app: {
+					name: 'same-component-name',
+					version: '1.0.0'
+				}
+			},
+			root
+		);
+		const firstInjection = resolveInjection(
+			{
+				name: 'first-panel',
+				injectAt: 'body',
+				component: './first/App.vue',
+				framework: 'Vue'
+			},
+			{
+				root,
+				source: config.source,
+				injectionDefaults: defaultInjectionDefaults,
+				componentPath: path.join(root, 'injections/first/App.vue')
+			}
+		);
+		const secondInjection = resolveInjection(
+			{
+				name: 'second-panel',
+				injectAt: 'body',
+				component: './second/App.vue',
+				framework: 'Vue'
+			},
+			{
+				root,
+				source: config.source,
+				injectionDefaults: defaultInjectionDefaults,
+				componentPath: path.join(root, 'injections/second/App.vue')
+			}
+		);
+		const scanResult: ScannerResult = {
+			config,
+			injectionDefaults: defaultInjectionDefaults,
+			manifestFile: path.join(root, 'injections/manifest.ts'),
+			manifestDependencies: [],
+			moduleManifestDependencies: [],
+			runtimeSetupFiles: [],
+			runtimeDependencies: [],
+			injections: [firstInjection, secondInjection],
+			frameworks: ['Vue']
+		};
+
+		const result = generate(scanResult);
+
+		expect(result.code).toContain(
+			'makooTasks.push(inject({"id":"first-panel","injectAt":"body","artifact":Injection_first_panel,"options":'
+		);
+		expect(result.code).toContain(
+			'makooTasks.push(inject({"id":"second-panel","injectAt":"body","artifact":Injection_second_panel,"options":'
+		);
 	});
 
 	it('renders runtime setup imports before component imports', () => {

--- a/packages/cli/test/hmr.test.ts
+++ b/packages/cli/test/hmr.test.ts
@@ -115,7 +115,9 @@ describe('makooMonkey dev HMR', () => {
 
 			const load = getHook(plugin.load);
 			const initialCode = await load?.call({}, RESOLVED_ID, {});
-			expect(String(initialCode)).toContain('makooTasks.push(inject("#old"');
+			expect(String(initialCode)).toContain(
+				'makooTasks.push(inject({"id":"widget","injectAt":"#old","artifact":Injection_widget'
+			);
 			expect(String(initialCode)).toContain('makoo.start(makooTasks)');
 
 			const manifestFile = path.join(root, 'injections/manifest.ts');
@@ -132,7 +134,9 @@ describe('makooMonkey dev HMR', () => {
 			await dev.emit('change', manifestFile);
 
 			const updatedCode = await load?.call({} as never, RESOLVED_ID, {} as never);
-			expect(String(updatedCode)).toContain('makooTasks.push(inject("#new"');
+			expect(String(updatedCode)).toContain(
+				'makooTasks.push(inject({"id":"widget","injectAt":"#new","artifact":Injection_widget'
+			);
 			expect(dev.invalidateModule).toHaveBeenCalledTimes(1);
 			expect(dev.hotSend).toHaveBeenCalledWith(
 				expect.objectContaining({
@@ -172,7 +176,9 @@ describe('makooMonkey dev HMR', () => {
 
 			const load = getHook(plugin.load);
 			const initialCode = await load?.call({} as never, RESOLVED_ID, {} as never);
-			expect(String(initialCode)).toContain('makooTasks.push(inject("#old"');
+			expect(String(initialCode)).toContain(
+				'makooTasks.push(inject({"id":"widget","injectAt":"#old","artifact":Injection_widget'
+			);
 			expect(String(initialCode)).toContain('makoo.start(makooTasks)');
 
 			const manifestFile = path.join(root, 'injections/manifest.ts');
@@ -201,7 +207,9 @@ describe('makooMonkey dev HMR', () => {
 			const currentCode = await load?.call({} as never, RESOLVED_ID, {} as never);
 
 			expect(result).toEqual([componentModule]);
-			expect(String(currentCode)).toContain('makooTasks.push(inject("#old"');
+			expect(String(currentCode)).toContain(
+				'makooTasks.push(inject({"id":"widget","injectAt":"#old","artifact":Injection_widget'
+			);
 			expect(String(currentCode)).toContain('makoo.start(makooTasks)');
 			expect(dev.invalidateModule).not.toHaveBeenCalled();
 			expect(dev.hotSend).not.toHaveBeenCalled();

--- a/packages/cli/test/integration.test.ts
+++ b/packages/cli/test/integration.test.ts
@@ -177,7 +177,8 @@ describe('makoo build integration', () => {
 		expect(userscript).toContain('__makooRuntimeSetup');
 		expect(userscript).toContain('createReactAdapter');
 		expect(userscript).toContain('createMakoo');
-		expect(userscript).toContain('inject("body"');
+		expect(userscript).toContain('"id": "hello-widget"');
+		expect(userscript).toContain('"injectAt": "body"');
 		expect(userscript).toContain('makoo.start(makooTasks)');
 		expect(userscript).not.toContain('virtual:makoo/entry');
 	});

--- a/packages/cli/test/makooPlugin.test.ts
+++ b/packages/cli/test/makooPlugin.test.ts
@@ -88,7 +88,9 @@ describe('makooMonkey', () => {
 			await buildStart?.call({} as never, {} as never);
 			const code = await load?.call({} as never, RESOLVED_ID, {} as never);
 
-			expect(String(code)).toContain('makooTasks.push(inject("#app"');
+			expect(String(code)).toContain(
+				'makooTasks.push(inject({"id":"widget","injectAt":"#app","artifact":Injection_widget'
+			);
 			expect(String(code)).toContain('makoo.start(makooTasks)');
 			expect(String(code)).not.toContain('import.meta.hot.accept');
 		});
@@ -108,7 +110,9 @@ describe('makooMonkey', () => {
 			await buildStart?.call({} as never, {} as never);
 			const code = await load?.call({} as never, RESOLVED_ID, {} as never);
 
-			expect(String(code)).toContain('makooTasks.push(inject("#app"');
+			expect(String(code)).toContain(
+				'makooTasks.push(inject({"id":"widget","injectAt":"#app","artifact":Injection_widget'
+			);
 			expect(String(code)).toContain('makoo.start(makooTasks)');
 			expect(String(code)).toContain('import.meta.hot.accept');
 			expect(String(code)).toContain("import.meta.hot.on('makoo:structural-hmr'");

--- a/packages/core/README.CN.md
+++ b/packages/core/README.CN.md
@@ -78,6 +78,29 @@ makoo.start([
 
 `inject()` 和 `listen()` 是声明 helper。它们不会触碰 DOM，也不会自己注册任务。`makoo.start([...])` 会注册传入批次里的声明，并立即调度这些任务。
 
+`inject()` 有两种写法。参数形式比较简洁：
+
+```ts
+inject('#toolbar', toolbarArtifact, {
+	alive: true
+});
+```
+
+对象形式会把声明字段放在一起。里面可选的 `id` 会作为任务 ID，适合后续需要查找或控制这个任务的场景：
+
+```ts
+inject({
+	id: 'settings-panel',
+	injectAt: '#settings',
+	artifact: settingsArtifact,
+	options: {
+		alive: true
+	}
+});
+```
+
+没有传 `id` 时，Makoo 会根据 artifact 和目标 selector 推导任务 ID。
+
 ```ts
 import { createMakoo, inject, listen } from '@makoojs/core';
 
@@ -97,7 +120,17 @@ const makoo = createMakoo({
 
 const started = makoo.start([
 	inject('#toolbar', toolbarArtifact, {
-		alive: true,
+		alive: true
+	}),
+	inject({
+		id: 'settings-panel',
+		injectAt: '#settings',
+		artifact: settingsArtifact,
+		options: {
+			alive: true
+		}
+	}),
+	inject('#save-tip', saveTipArtifact, {
 		on: listen('#save', 'click', () => {
 			console.log('save clicked');
 		})

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -78,6 +78,29 @@ makoo.start([
 
 `inject()` and `listen()` are declaration helpers. They do not touch the DOM and do not register tasks by themselves. `makoo.start([...])` registers the declarations in the provided batch and immediately schedules those tasks.
 
+`inject()` has two forms. The positional form is concise:
+
+```ts
+inject('#toolbar', toolbarArtifact, {
+	alive: true
+});
+```
+
+The object form keeps the declaration fields together. Its optional `id` is used as the task id, which is useful when you want to look up or control that task later:
+
+```ts
+inject({
+	id: 'settings-panel',
+	injectAt: '#settings',
+	artifact: settingsArtifact,
+	options: {
+		alive: true
+	}
+});
+```
+
+When `id` is omitted, Makoo infers a task id from the artifact and target selector.
+
 ```ts
 import { createMakoo, inject, listen } from '@makoojs/core';
 
@@ -97,7 +120,17 @@ const makoo = createMakoo({
 
 const started = makoo.start([
 	inject('#toolbar', toolbarArtifact, {
-		alive: true,
+		alive: true
+	}),
+	inject({
+		id: 'settings-panel',
+		injectAt: '#settings',
+		artifact: settingsArtifact,
+		options: {
+			alive: true
+		}
+	}),
+	inject('#save-tip', saveTipArtifact, {
 		on: listen('#save', 'click', () => {
 			console.log('save clicked');
 		})

--- a/packages/core/src/Makoo/createMakoo.ts
+++ b/packages/core/src/Makoo/createMakoo.ts
@@ -7,6 +7,7 @@ import type {
 	ArtifactOptions,
 	CreateMakooOptions,
 	MakooInjectionDeclaration,
+	MakooInjectionInput,
 	MakooListenerDeclaration,
 	MakooListenerOptions,
 	MakooRuntime,
@@ -57,11 +58,29 @@ export function inject<TArtifact>(
 	injectAt: string,
 	artifact: TArtifact,
 	options?: ArtifactOptions
+): MakooInjectionDeclaration<TArtifact>;
+export function inject<TArtifact>(
+	input: MakooInjectionInput<TArtifact>
+): MakooInjectionDeclaration<TArtifact>;
+export function inject<TArtifact>(
+	inputOrInjectAt: string | MakooInjectionInput<TArtifact>,
+	artifact?: TArtifact,
+	options?: ArtifactOptions
 ): MakooInjectionDeclaration<TArtifact> {
+	if (typeof inputOrInjectAt !== 'string') {
+		return {
+			kind: 'component',
+			...(inputOrInjectAt.id ? { id: inputOrInjectAt.id } : {}),
+			injectAt: inputOrInjectAt.injectAt,
+			artifact: inputOrInjectAt.artifact,
+			...(inputOrInjectAt.options ? { options: inputOrInjectAt.options } : {})
+		};
+	}
+
 	return {
 		kind: 'component',
-		injectAt,
-		artifact,
+		injectAt: inputOrInjectAt,
+		artifact: artifact as TArtifact,
 		...(options ? { options } : {})
 	};
 }
@@ -91,6 +110,7 @@ function registerDeclarations(
 	for (const declaration of declarations) {
 		if (declaration.kind === 'component') {
 			const result = registerInjection(runtime, {
+				...(declaration.id ? { id: declaration.id } : {}),
 				injectAt: declaration.injectAt,
 				artifact: declaration.artifact,
 				...(declaration.options ? { options: declaration.options } : {})

--- a/packages/core/src/Makoo/types.ts
+++ b/packages/core/src/Makoo/types.ts
@@ -31,8 +31,16 @@ export type ArtifactOptions = {
 	hooks?: LifecycleHookMap;
 };
 
+export type MakooInjectionInput<TArtifact = unknown> = {
+	id?: string;
+	injectAt: string;
+	artifact: TArtifact;
+	options?: ArtifactOptions;
+};
+
 export type MakooInjectionDeclaration<TArtifact = unknown> = {
 	kind: 'component';
+	id?: string;
 	injectAt: string;
 	artifact: TArtifact;
 	options?: ArtifactOptions;

--- a/packages/core/src/Task/TaskRegister.ts
+++ b/packages/core/src/Task/TaskRegister.ts
@@ -13,8 +13,10 @@ import type {
 	TaskActivitySignal,
 	TaskListenerFeature
 } from './types';
+import { resolveInjectionTaskId } from './util';
 
 export type InjectionDeclaration<TArtifact = unknown> = {
+	id?: string;
 	injectAt: string;
 	artifact: TArtifact;
 	options?: ArtifactOptions;
@@ -124,9 +126,14 @@ export function registerInjection<TArtifact>(
 	runtime: MakooRuntimeState,
 	declaration: InjectionDeclaration<TArtifact>
 ): _RegisterResult {
-	const { injectAt, artifact, options } = declaration;
+	const { id, injectAt, artifact, options } = declaration;
 	const artifactName = getArtifactName(artifact);
-	const taskId: string = artifactName ? `${artifactName}@${injectAt}` : `artifact-${injectAt}`;
+	const taskId = resolveInjectionTaskId(runtime, {
+		id,
+		artifactName,
+		injectAt,
+		artifact
+	});
 	const withEvent = Boolean(options?.on);
 	const listenerEvent = options?.on?.type;
 	const listenAt = options?.on?.listenAt;

--- a/packages/core/src/Task/util.ts
+++ b/packages/core/src/Task/util.ts
@@ -1,4 +1,8 @@
+import type { MakooRuntimeState } from '../runtime/types';
 import type { ArtifactTask, Task, TaskListenerFeature } from './types';
+
+const inferredArtifactIds = new WeakMap<object, string>();
+let inferredArtifactIdCount = 0;
 
 export function isArtifactTask(task: Task): task is ArtifactTask {
 	return task.kind === 'component';
@@ -19,4 +23,65 @@ export function getTaskListener(task: Task): TaskListenerFeature | undefined {
 	}
 
 	return listener;
+}
+
+export function resolveInjectionTaskId(
+	runtime: MakooRuntimeState,
+	input: {
+		id?: string;
+		artifactName: string;
+		injectAt: string;
+		artifact: unknown;
+	}
+): string {
+	if (input.id) {
+		return input.id;
+	}
+
+	const baseTaskId = input.artifactName
+		? `${input.artifactName}@${input.injectAt}`
+		: `artifact-${input.injectAt}`;
+	const existingBaseTask = runtime.taskContext.get(baseTaskId);
+	if (!existingBaseTask) {
+		return baseTaskId;
+	}
+	if (isArtifactTask(existingBaseTask) && existingBaseTask.artifact === input.artifact) {
+		return baseTaskId;
+	}
+
+	const artifactIdentity = getInferredArtifactIdentity(input.artifact);
+	let fallbackTaskId = `${input.artifactName}#${artifactIdentity}@${input.injectAt}`;
+	let suffix = 2;
+	while (true) {
+		const existingFallbackTask = runtime.taskContext.get(fallbackTaskId);
+		if (!existingFallbackTask) {
+			return fallbackTaskId;
+		}
+		if (
+			isArtifactTask(existingFallbackTask) &&
+			existingFallbackTask.artifact === input.artifact
+		) {
+			return fallbackTaskId;
+		}
+		fallbackTaskId = `${input.artifactName}#${artifactIdentity}-${suffix}@${input.injectAt}`;
+		suffix++;
+	}
+}
+
+function getInferredArtifactIdentity(artifact: unknown): string {
+	if ((typeof artifact !== 'object' && typeof artifact !== 'function') || artifact === null) {
+		inferredArtifactIdCount++;
+		return `artifact-${inferredArtifactIdCount}`;
+	}
+
+	const key = artifact as object;
+	const cached = inferredArtifactIds.get(key);
+	if (cached) {
+		return cached;
+	}
+
+	inferredArtifactIdCount++;
+	const id = `artifact-${inferredArtifactIdCount}`;
+	inferredArtifactIds.set(key, id);
+	return id;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -34,6 +34,7 @@ export type {
 	InjectionConfig,
 	MakooDefaults,
 	MakooInjectionDeclaration,
+	MakooInjectionInput,
 	MakooListenerDeclaration,
 	MakooListenerOptions,
 	MakooRuntime,

--- a/packages/core/test/MakooDeclaration.test.ts
+++ b/packages/core/test/MakooDeclaration.test.ts
@@ -30,6 +30,30 @@ describe('Makoo declarations', () => {
 		});
 	});
 
+	it('should create component injection declarations from object input', () => {
+		const component = createVueComponent('DeclaredObjectComp');
+		const declaration = inject({
+			id: 'declared-object',
+			injectAt: '#object-app',
+			artifact: component,
+			options: {
+				alive: true,
+				scope: 'global'
+			}
+		});
+
+		expect(declaration).toEqual({
+			kind: 'component',
+			id: 'declared-object',
+			injectAt: '#object-app',
+			artifact: component,
+			options: {
+				alive: true,
+				scope: 'global'
+			}
+		});
+	});
+
 	it('should create listener declarations that can be used standalone or inside inject options', () => {
 		const signal = createActivityStore(true);
 		const activitySignal = () => signal;

--- a/packages/core/test/TaskRegister.test.ts
+++ b/packages/core/test/TaskRegister.test.ts
@@ -217,6 +217,49 @@ describe('TaskRegister', () => {
 		});
 	});
 
+	it('should prefer explicit injection id over inferred artifact name', () => {
+		const component = createVueComponent('CompWithId');
+		const result = registerInjection(runtime, {
+			id: 'custom-panel',
+			injectAt: '#id-host',
+			artifact: component
+		});
+		const context = taskContext.get(result.taskId);
+
+		expect(result).toEqual({ taskId: 'custom-panel', isSuccess: true });
+		expect(context).toMatchObject({
+			kind: 'component',
+			taskId: 'custom-panel',
+			artifactName: 'CompWithId',
+			injectAt: '#id-host',
+			artifact: component
+		});
+	});
+
+	it('should treat repeated explicit injection id as duplicate', () => {
+		const firstComponent = createVueComponent('ExplicitA');
+		const secondComponent = createVueComponent('ExplicitB');
+
+		const first = registerInjection(runtime, {
+			id: 'same-explicit-id',
+			injectAt: '#explicit-a',
+			artifact: firstComponent
+		});
+		const second = registerInjection(runtime, {
+			id: 'same-explicit-id',
+			injectAt: '#explicit-b',
+			artifact: secondComponent
+		});
+
+		expect(first).toEqual({ taskId: 'same-explicit-id', isSuccess: true });
+		expect(second).toEqual({
+			taskId: 'same-explicit-id',
+			isSuccess: true,
+			isDuplicate: true
+		});
+		expect(taskContext.taskRecords).toHaveLength(1);
+	});
+
 	it('should return existing result for duplicate component registration', () => {
 		const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
@@ -232,6 +275,54 @@ describe('TaskRegister', () => {
 		});
 		expect(taskContext.taskRecords).toHaveLength(1);
 		expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('already registered'));
+	});
+
+	it('should avoid duplicate fallback when different artifacts share name and target', () => {
+		const firstComponent = createVueComponent('SharedName');
+		const secondComponent = createVueComponent('SharedName');
+
+		const first = registerInjection(runtime, { injectAt: '#shared', artifact: firstComponent });
+		const second = registerInjection(runtime, {
+			injectAt: '#shared',
+			artifact: secondComponent
+		});
+
+		expect(first).toEqual({ taskId: 'SharedName@#shared', isSuccess: true });
+		expect(second).toMatchObject({
+			isSuccess: true
+		});
+		expect(second.isDuplicate).toBeUndefined();
+		expect(second.taskId).not.toBe('SharedName@#shared');
+		expect(second.taskId).toMatch(/^SharedName#artifact-\d+@#shared$/);
+		expect(taskContext.taskRecords).toHaveLength(2);
+		expect(taskContext.get(second.taskId)).toMatchObject({
+			artifact: secondComponent,
+			artifactName: 'SharedName',
+			injectAt: '#shared'
+		});
+	});
+
+	it('should treat repeated inferred fallback task as duplicate for the same artifact', () => {
+		const firstComponent = createVueComponent('RepeatedSharedName');
+		const secondComponent = createVueComponent('RepeatedSharedName');
+
+		registerInjection(runtime, { injectAt: '#repeated-shared', artifact: firstComponent });
+		const firstFallback = registerInjection(runtime, {
+			injectAt: '#repeated-shared',
+			artifact: secondComponent
+		});
+		const secondFallback = registerInjection(runtime, {
+			injectAt: '#repeated-shared',
+			artifact: secondComponent
+		});
+
+		expect(firstFallback.isDuplicate).toBeUndefined();
+		expect(secondFallback).toEqual({
+			taskId: firstFallback.taskId,
+			isSuccess: true,
+			isDuplicate: true
+		});
+		expect(taskContext.taskRecords).toHaveLength(2);
 	});
 
 	it('should reuse generated anonymous name for same component reference', () => {

--- a/packages/core/test/createMakoo.test.ts
+++ b/packages/core/test/createMakoo.test.ts
@@ -117,6 +117,43 @@ describe('createMakoo', () => {
 		expect(callback).toHaveBeenCalledTimes(2);
 	});
 
+	it('should start object-form component declarations with explicit task id', () => {
+		const host = document.createElement('div');
+		host.id = 'object-host';
+		document.body.appendChild(host);
+		const artifact = { name: 'PlainObject' };
+		let mountInput: AdapterMountInput<PlainArtifact> | undefined;
+		const mount = vi.fn((input: AdapterMountInput<PlainArtifact>) => {
+			mountInput = input;
+			return { handle: { mounted: true }, instance: input.artifact };
+		});
+		const makoo = createMakoo({
+			adapters: [createPlainAdapter(mount)]
+		});
+
+		const started = makoo.start([
+			inject({
+				id: 'object-panel',
+				injectAt: '#object-host',
+				artifact
+			})
+		]);
+		const task = started.get('object-panel');
+
+		expect(task).toMatchObject({
+			kind: 'component',
+			taskId: 'object-panel'
+		});
+		expect(mountInput).toMatchObject({
+			taskId: 'object-panel',
+			injectAt: '#object-host',
+			makoo: expect.objectContaining({
+				taskId: 'object-panel',
+				injectAt: '#object-host'
+			})
+		});
+	});
+
 	it('should throw a task error when starting an empty batch', () => {
 		const makoo = createMakoo();
 


### PR DESCRIPTION
This pull request introduces a new object-form API for `inject()` in `@makoojs/core`, improves task id handling to prevent duplicate detection, and updates the CLI to generate object-form injection declarations with stable ids. Documentation and tests are updated to reflect these changes, ensuring both English and Chinese docs cover the new API. The most important changes are summarized below.

---

**Core API Enhancements:**

* Added support for object-form `inject()` declarations in `@makoojs/core`, allowing usage like `inject({ id, injectAt, artifact, options })` in addition to the existing positional form. The optional `id` field provides a stable task id for later lookup and control. [[1]](diffhunk://#diff-4340d3330a976a67a2275b6a2ea9f930fb851979aa3ac5d65f43f61e9bf6f8b8R61-R83) [[2]](diffhunk://#diff-7f1033a34b8b81f9a390195afd0b8eabe38061f7d455497c35de6379f2f7fafdR34-R43) [[3]](diffhunk://#diff-4340d3330a976a67a2275b6a2ea9f930fb851979aa3ac5d65f43f61e9bf6f8b8R113) [[4]](diffhunk://#diff-e5fe11733029771a5a2511a9e56da83178bbf7664558c15a338ce84b2b0ad07aR1-R36)
* Improved injection task id inference to avoid false duplicate detection when different artifacts share the same name and target selector, ensuring only true duplicates are skipped. [[1]](diffhunk://#diff-7d493d55bb7f56667eb09a266bece7128b79d9a3916a3db9e7b2d6a958834400L127-R136) [[2]](diffhunk://#diff-e5fe11733029771a5a2511a9e56da83178bbf7664558c15a338ce84b2b0ad07aR1-R36)

**CLI Improvements:**

* The CLI now generates object-form `inject()` declarations and uses each module id as the injection task id, preventing collisions for same-named components and ensuring stable runtime behavior. [[1]](diffhunk://#diff-044d9e7f11ad54c346442742edf78390ee558a5bcf7ff2222c8aec9de5c7b761L37-R43) [[2]](diffhunk://#diff-d88337d8811e814b34d0a77b07215820cf6a5802c7f6cecd5bcceb34dc11f08bL80-R82) [[3]](diffhunk://#diff-d88337d8811e814b34d0a77b07215820cf6a5802c7f6cecd5bcceb34dc11f08bL145-R212) [[4]](diffhunk://#diff-c06464dcbca73e5ee1cb30c053c2a98741153c6e1454a3ac89b36eb099f6341fL118-R120) [[5]](diffhunk://#diff-c06464dcbca73e5ee1cb30c053c2a98741153c6e1454a3ac89b36eb099f6341fL135-R139) [[6]](diffhunk://#diff-c06464dcbca73e5ee1cb30c053c2a98741153c6e1454a3ac89b36eb099f6341fL175-R181) [[7]](diffhunk://#diff-c06464dcbca73e5ee1cb30c053c2a98741153c6e1454a3ac89b36eb099f6341fL204-R212) [[8]](diffhunk://#diff-fc3decc822f0570c22d2f25aaec78c00461442522e9a78fc24daf1daf56e8938L91-R93) [[9]](diffhunk://#diff-fc3decc822f0570c22d2f25aaec78c00461442522e9a78fc24daf1daf56e8938L111-R115) [[10]](diffhunk://#diff-dc3537f41c102e79008db3c053ebbf58cdb2532286728ecb8b5a7986961e4da5L180-R181) [[11]](diffhunk://#diff-e5fe11733029771a5a2511a9e56da83178bbf7664558c15a338ce84b2b0ad07aR1-R36)

**Documentation Updates:**

* Updated English and Chinese documentation (`README.md`, `README.CN.md`, and API docs) to explain both forms of `inject()`, demonstrate usage, and clarify task id inference. [[1]](diffhunk://#diff-fa0bdb1c6631f048634c61a94d5350c3935c92075c4150742d09eba87ddd515bR81-R103) [[2]](diffhunk://#diff-fa0bdb1c6631f048634c61a94d5350c3935c92075c4150742d09eba87ddd515bL100-R133) [[3]](diffhunk://#diff-c188fabc3c59ea01c5f492fdea13a909f9c1e4f2443a8265595829118ba1c7e4R81-R103) [[4]](diffhunk://#diff-c188fabc3c59ea01c5f492fdea13a909f9c1e4f2443a8265595829118ba1c7e4L100-R133)

**Type and Internal Refactoring:**

* Introduced the `MakooInjectionInput` type and updated related types and internal code to support the new object-form API and optional `id` field. [[1]](diffhunk://#diff-7f1033a34b8b81f9a390195afd0b8eabe38061f7d455497c35de6379f2f7fafdR34-R43) [[2]](diffhunk://#diff-4340d3330a976a67a2275b6a2ea9f930fb851979aa3ac5d65f43f61e9bf6f8b8R10) [[3]](diffhunk://#diff-7d493d55bb7f56667eb09a266bece7128b79d9a3916a3db9e7b2d6a958834400R16-R19)

**Test Coverage:**

* Updated and expanded test cases to verify object-form injection, stable task ids, and prevention of duplicate task registration for same-named components. [[1]](diffhunk://#diff-d88337d8811e814b34d0a77b07215820cf6a5802c7f6cecd5bcceb34dc11f08bL80-R82) [[2]](diffhunk://#diff-d88337d8811e814b34d0a77b07215820cf6a5802c7f6cecd5bcceb34dc11f08bL145-R212) [[3]](diffhunk://#diff-c06464dcbca73e5ee1cb30c053c2a98741153c6e1454a3ac89b36eb099f6341fL118-R120) [[4]](diffhunk://#diff-c06464dcbca73e5ee1cb30c053c2a98741153c6e1454a3ac89b36eb099f6341fL135-R139) [[5]](diffhunk://#diff-c06464dcbca73e5ee1cb30c053c2a98741153c6e1454a3ac89b36eb099f6341fL175-R181) [[6]](diffhunk://#diff-c06464dcbca73e5ee1cb30c053c2a98741153c6e1454a3ac89b36eb099f6341fL204-R212) [[7]](diffhunk://#diff-fc3decc822f0570c22d2f25aaec78c00461442522e9a78fc24daf1daf56e8938L91-R93) [[8]](diffhunk://#diff-fc3decc822f0570c22d2f25aaec78c00461442522e9a78fc24daf1daf56e8938L111-R115) [[9]](diffhunk://#diff-dc3537f41c102e79008db3c053ebbf58cdb2532286728ecb8b5a7986961e4da5L180-R181)

These changes make the injection API more robust, flexible, and easier to use in complex scenarios with multiple similar components.