### PR TITLE
Fix/preserve inferred injection fallback

### DIFF
--- a/.changeset/afraid-laws-accept.md
+++ b/.changeset/afraid-laws-accept.md
@@ -1,0 +1,11 @@
+---
+"@makoojs/core": patch
+---
+
+🐛 Preserve Inferred Fallback Injection IDs
+
+`@makoojs/core` now preserves inferred fallback injection task ids when the original base task has been destroyed.
+
+Previously, if two different artifacts shared the same artifact name and injection target, the second artifact could receive a fallback task id. If the base task was later destroyed while the fallback task remained active, registering the second artifact again could move it back to the base id and mount the same artifact twice.
+
+Makoo now checks for a live fallback task for the same artifact before reusing the base id, so repeated registrations continue to resolve to the existing fallback task and are correctly treated as duplicates.

--- a/.changeset/huge-baths-stick.md
+++ b/.changeset/huge-baths-stick.md
@@ -1,0 +1,7 @@
+---
+"@makoojs/create-makoo": patch
+---
+
+🔧 Refresh Scaffolded Makoo Versions
+
+Updated the recommended Makoo package versions used by `@makoojs/create-makoo` templates so new projects start with the latest compatible `@makoojs/core` runtime behavior.

--- a/packages/core/src/Task/util.ts
+++ b/packages/core/src/Task/util.ts
@@ -42,10 +42,33 @@ export function resolveInjectionTaskId(
 		? `${input.artifactName}@${input.injectAt}`
 		: `artifact-${input.injectAt}`;
 	const existingBaseTask = runtime.taskContext.get(baseTaskId);
-	if (!existingBaseTask) {
+
+	if (
+		existingBaseTask &&
+		isArtifactTask(existingBaseTask) &&
+		existingBaseTask.artifact === input.artifact
+	) {
 		return baseTaskId;
 	}
-	if (isArtifactTask(existingBaseTask) && existingBaseTask.artifact === input.artifact) {
+
+	// Reuse a live fallback task before allowing the artifact to move back to the base id.
+	const cachedArtifactIdentity: string | undefined = inferredArtifactIds.get(
+		input.artifact as object
+	);
+	if (cachedArtifactIdentity) {
+		const existingFallbackTaskId = `${input.artifactName}#${cachedArtifactIdentity}@${input.injectAt}`;
+		const existingFallbackTask = runtime.taskContext.get(existingFallbackTaskId);
+
+		if (
+			existingFallbackTask &&
+			isArtifactTask(existingFallbackTask) &&
+			existingFallbackTask.artifact === input.artifact
+		) {
+			return existingFallbackTaskId;
+		}
+	}
+
+	if (!existingBaseTask) {
 		return baseTaskId;
 	}
 

--- a/packages/core/test/TaskRegister.test.ts
+++ b/packages/core/test/TaskRegister.test.ts
@@ -325,6 +325,35 @@ describe('TaskRegister', () => {
 		expect(taskContext.taskRecords).toHaveLength(2);
 	});
 
+	it('should preserve inferred fallback task after base task is destroyed', () => {
+		const firstComponent = createVueComponent('DestroyedBaseSharedName');
+		const secondComponent = createVueComponent('DestroyedBaseSharedName');
+
+		const base = registerInjection(runtime, {
+			injectAt: '#destroyed-base-shared',
+			artifact: firstComponent
+		});
+		const firstFallback = registerInjection(runtime, {
+			injectAt: '#destroyed-base-shared',
+			artifact: secondComponent
+		});
+
+		taskContext.destroy(base.taskId);
+
+		const secondFallback = registerInjection(runtime, {
+			injectAt: '#destroyed-base-shared',
+			artifact: secondComponent
+		});
+
+		expect(firstFallback.taskId).not.toBe(base.taskId);
+		expect(secondFallback).toEqual({
+			taskId: firstFallback.taskId,
+			isSuccess: true,
+			isDuplicate: true
+		});
+		expect(taskContext.taskRecords).toHaveLength(1);
+	});
+
 	it('should reuse generated anonymous name for same component reference', () => {
 		const anonymous = createVueComponent('anonymous');
 		const a = registerInjection(runtime, { injectAt: '#a', artifact: anonymous });

--- a/packages/create-makoo/src/template/makooVersion.ts
+++ b/packages/create-makoo/src/template/makooVersion.ts
@@ -1,7 +1,7 @@
 export const recommendedMakooVersions = {
-	core: '^0.2.1',
+	core: '^0.2.2',
 	cli: '^0.3.2',
 	vue: '^0.1.2',
 	react: '^0.1.2',
-	'create-makoo': '^0.1.5'
+	'create-makoo': '^0.1.6'
 } as const satisfies Record<string, string>;


### PR DESCRIPTION
This pull request addresses a bug in artifact injection handling in `@makoojs/core` and updates the recommended package versions in `@makoojs/create-makoo`. The main fix ensures that inferred fallback injection task IDs are preserved when the base task is destroyed, preventing duplicate artifact mounting. It also refreshes the starter template versions to align with the latest runtime behavior.

**Bug Fixes: Artifact Injection Handling**
* Updated `resolveInjectionTaskId` in `packages/core/src/Task/util.ts` to reuse a live fallback task ID if the base task has been destroyed, ensuring that repeated registrations of the same artifact are correctly treated as duplicates and not remounted.
* Added a test in `packages/core/test/TaskRegister.test.ts` to verify that inferred fallback task IDs are preserved after the base task is destroyed, confirming the fix works as intended.
* Added a changeset entry documenting the bug fix and its impact on artifact injection task ID behavior. (`.changeset/afraid-laws-accept.md`)

**Template and Version Updates**
* Updated the recommended `@makoojs/core` version in `packages/create-makoo/src/template/makooVersion.ts` from `^0.2.1` to `^0.2.2` to ensure new projects use the latest runtime.
* Added a changeset entry to note the refresh of scaffolded Makoo versions in `@makoojs/create-makoo` templates. (`.changeset/huge-baths-stick.md`)