### PR TITLE
feat: support listener capture phase

### DIFF
--- a/.changeset/tasty-meteors-try.md
+++ b/.changeset/tasty-meteors-try.md
@@ -1,0 +1,7 @@
+---
+"@makoojs/core": patch
+"@makoojs/cli": patch
+"@makoojs/create-makoo": patch
+---
+
+Add a capture option to listener injection so that operations can be performed during the capture phase.

--- a/README.CN.md
+++ b/README.CN.md
@@ -224,10 +224,11 @@ match: {
 ```ts
 export default defineInjections({
 	listeners: {
-		escapeClose: {
-			listenAt: 'body',
-			type: 'keydown',
-			callback: (event) => {
+			escapeClose: {
+				listenAt: 'body',
+				type: 'keydown',
+				capture: true,
+				callback: (event) => {
 				if (event instanceof KeyboardEvent && event.key === 'Escape') console.log('close');
 			},
 			match: ['https://example.com/*']
@@ -236,7 +237,7 @@ export default defineInjections({
 });
 ```
 
-Makoo 会为该条目生成 `listen({ id: 'escapeClose', ... })`。listener 也支持 `enabled`、`activitySignal` 和与模块相同的 `match` 规则；数组形式需要用 `name` 提供稳定 ID。`listenAt` 必须是 CSS 选择器，不支持使用 `document` 或 `window` 作为监听目标。
+Makoo 会为该条目生成 `listen({ id: 'escapeClose', ... })`。listener 也支持 `enabled`、`capture`、`activitySignal` 和与模块相同的 `match` 规则。`capture` 默认为 `false`，设置为 `true` 后会在 DOM 捕获阶段监听事件；数组形式需要用 `name` 提供稳定 ID。`listenAt` 必须是 CSS 选择器，不支持使用 `document` 或 `window` 作为监听目标。
 
 独立 listener 只能声明在顶层 manifest。模块级 manifest 只描述一个 injection 模块，当前尚不支持描述一个listener；事件属于组件任务时使用模块的 `on` 字段。
 

--- a/README.CN.md
+++ b/README.CN.md
@@ -224,11 +224,11 @@ match: {
 ```ts
 export default defineInjections({
 	listeners: {
-			escapeClose: {
-				listenAt: 'body',
-				type: 'keydown',
-				capture: true,
-				callback: (event) => {
+		escapeClose: {
+			listenAt: 'body',
+			type: 'keydown',
+			capture: true,
+			callback: (event) => {
 				if (event instanceof KeyboardEvent && event.key === 'Escape') console.log('close');
 			},
 			match: ['https://example.com/*']

--- a/README.md
+++ b/README.md
@@ -226,11 +226,11 @@ the listener task ID:
 ```ts
 export default defineInjections({
 	listeners: {
-			escapeClose: {
-				listenAt: 'body',
-				type: 'keydown',
-				capture: true,
-				callback: (event) => {
+		escapeClose: {
+			listenAt: 'body',
+			type: 'keydown',
+			capture: true,
+			callback: (event) => {
 				if (event instanceof KeyboardEvent && event.key === 'Escape') console.log('close');
 			},
 			match: ['https://example.com/*']

--- a/README.md
+++ b/README.md
@@ -226,10 +226,11 @@ the listener task ID:
 ```ts
 export default defineInjections({
 	listeners: {
-		escapeClose: {
-			listenAt: 'body',
-			type: 'keydown',
-			callback: (event) => {
+			escapeClose: {
+				listenAt: 'body',
+				type: 'keydown',
+				capture: true,
+				callback: (event) => {
 				if (event instanceof KeyboardEvent && event.key === 'Escape') console.log('close');
 			},
 			match: ['https://example.com/*']
@@ -239,7 +240,8 @@ export default defineInjections({
 ```
 
 Makoo generates `listen({ id: 'escapeClose', ... })` for this entry. Listeners also support
-`enabled`, `activitySignal`, and the same `match` rules as modules. Use `name` in array form
+`enabled`, `capture`, `activitySignal`, and the same `match` rules as modules. `capture` defaults
+to `false`; set it to `true` to listen during the DOM capture phase. Use `name` in array form
 when a listener needs a stable ID. `listenAt` must be a CSS selector; `document` and `window`
 are not supported listener targets.
 

--- a/apps/docs-website/docs/api/cli.md
+++ b/apps/docs-website/docs/api/cli.md
@@ -304,6 +304,7 @@ type InjectionModuleListenerConfig = {
 	listenAt: string;
 	type: string;
 	callback: EventListener;
+	capture?: boolean;
 	activitySignal?: () => ActivitySignalSource<boolean>;
 };
 

--- a/apps/docs-website/docs/zh/api/cli.md
+++ b/apps/docs-website/docs/zh/api/cli.md
@@ -304,6 +304,7 @@ type InjectionModuleListenerConfig = {
 	listenAt: string;
 	type: string;
 	callback: EventListener;
+	capture?: boolean;
 	activitySignal?: () => ActivitySignalSource<boolean>;
 };
 

--- a/packages/cli/README.CN.md
+++ b/packages/cli/README.CN.md
@@ -207,11 +207,11 @@ export default defineInjections({
 		}
 	},
 	listeners: {
-			escape: {
-				listenAt: 'body',
-				type: 'keydown',
-				capture: true,
-				callback: onEscape
+		escape: {
+			listenAt: 'body',
+			type: 'keydown',
+			capture: true,
+			callback: onEscape
 		}
 	}
 });

--- a/packages/cli/README.CN.md
+++ b/packages/cli/README.CN.md
@@ -207,10 +207,11 @@ export default defineInjections({
 		}
 	},
 	listeners: {
-		escape: {
-			listenAt: 'body',
-			type: 'keydown',
-			callback: onEscape
+			escape: {
+				listenAt: 'body',
+				type: 'keydown',
+				capture: true,
+				callback: onEscape
 		}
 	}
 });
@@ -245,6 +246,7 @@ export default defineInjection({
 	on: {
 		listenAt: 'body',
 		type: 'click',
+		capture: true,
 		callback: onClick
 	}
 });
@@ -304,6 +306,7 @@ type InjectionModuleListenerConfig = {
 	listenAt: string;
 	type: string;
 	callback: EventListener;
+	capture?: boolean;
 	activitySignal?: () => ActivitySignalSource<boolean>;
 };
 
@@ -313,6 +316,9 @@ type InjectionListenerConfig = InjectionModuleListenerConfig & {
 	match?: InjectionMatchConfig;
 };
 ```
+
+设置 `capture: true` 后，listener 会在 DOM 捕获阶段处理事件。该字段默认为 `false`，
+未配置时使用冒泡阶段。事件 listener 的 signal 仍由 Makoo 内部管理。
 
 ### `InjectionFramework`
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -207,11 +207,11 @@ export default defineInjections({
 		}
 	},
 	listeners: {
-			escape: {
-				listenAt: 'body',
-				type: 'keydown',
-				capture: true,
-				callback: onEscape
+		escape: {
+			listenAt: 'body',
+			type: 'keydown',
+			capture: true,
+			callback: onEscape
 		}
 	}
 });

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -207,10 +207,11 @@ export default defineInjections({
 		}
 	},
 	listeners: {
-		escape: {
-			listenAt: 'body',
-			type: 'keydown',
-			callback: onEscape
+			escape: {
+				listenAt: 'body',
+				type: 'keydown',
+				capture: true,
+				callback: onEscape
 		}
 	}
 });
@@ -245,6 +246,7 @@ export default defineInjection({
 	on: {
 		listenAt: 'body',
 		type: 'click',
+		capture: true,
 		callback: onClick
 	}
 });
@@ -304,6 +306,7 @@ type InjectionModuleListenerConfig = {
 	listenAt: string;
 	type: string;
 	callback: EventListener;
+	capture?: boolean;
 	activitySignal?: () => ActivitySignalSource<boolean>;
 };
 
@@ -313,6 +316,9 @@ type InjectionListenerConfig = InjectionModuleListenerConfig & {
 	match?: InjectionMatchConfig;
 };
 ```
+
+Set `capture: true` to listen during the DOM capture phase. It defaults to `false`, so listeners
+use the bubbling phase unless explicitly configured. Makoo manages the event listener signal.
 
 ### `InjectionFramework`
 

--- a/packages/cli/src/config/types.ts
+++ b/packages/cli/src/config/types.ts
@@ -127,6 +127,7 @@ export type InjectionModuleListenerConfig = {
 	listenAt: string;
 	type: string;
 	callback: EventListener;
+	capture?: boolean;
 	activitySignal?: () => ActivitySignalSource<boolean>;
 };
 

--- a/packages/cli/src/generator/render/init/registerComp.ts
+++ b/packages/cli/src/generator/render/init/registerComp.ts
@@ -67,6 +67,9 @@ function renderArtifactOptions(
 			`"listenAt":${JSON.stringify(componentMeta.on.listenAt)}`,
 			`"type":${JSON.stringify(componentMeta.on.type)}`,
 			`"callback":${renderManifestReference(manifestBinding.on.callback)}`,
+			typeof componentMeta.on.capture !== 'undefined'
+				? `"capture":${JSON.stringify(componentMeta.on.capture)}`
+				: null,
 			componentMeta.on.activitySignal
 				? renderActivitySignal(
 						componentMeta.moduleId,

--- a/packages/cli/src/generator/render/init/registerListener.ts
+++ b/packages/cli/src/generator/render/init/registerListener.ts
@@ -20,6 +20,9 @@ export function renderRegisterListener(
 			`"listenAt":${JSON.stringify(listener.listenAt)}`,
 			`"type":${JSON.stringify(listener.type)}`,
 			`"callback":${renderManifestReference(manifestBinding.callback)}`,
+			typeof listener.capture !== 'undefined'
+				? `"capture":${JSON.stringify(listener.capture)}`
+				: null,
 			listener.activitySignal
 				? renderActivitySignal(
 						listener.listenerId,

--- a/packages/cli/src/scanner/validation.ts
+++ b/packages/cli/src/scanner/validation.ts
@@ -43,6 +43,7 @@ export const InjectionModuleListenerSchema = z.object({
 	listenAt: z.string(),
 	type: z.string(),
 	callback: EventListenerSchema,
+	capture: z.boolean().optional(),
 	activitySignal: ActivitySignalSchema.optional()
 });
 

--- a/packages/cli/test/generator.test.ts
+++ b/packages/cli/test/generator.test.ts
@@ -43,6 +43,7 @@ describe('generate', () => {
 					listenAt: '#app',
 					type: 'click',
 					callback: () => 'clicked',
+					capture: false,
 					activitySignal: () => ({
 						get: () => true,
 						subscribe: () => () => {}
@@ -120,7 +121,7 @@ describe('generate', () => {
 		);
 		expect(result.code).toContain('"hooks":Manifest_0["injections"][0]["hooks"]');
 		expect(result.code).toContain(
-			'listen({"listenAt":"#app","type":"click","callback":Manifest_0["injections"][0]["on"]["callback"],"activitySignal":Manifest_0["injections"][0]["on"]["activitySignal"]})'
+			'listen({"listenAt":"#app","type":"click","callback":Manifest_0["injections"][0]["on"]["callback"],"capture":false,"activitySignal":Manifest_0["injections"][0]["on"]["activitySignal"]})'
 		);
 		expect(result.code).not.toContain('run-start');
 		expect(result.code).not.toContain('mounted');
@@ -329,6 +330,7 @@ describe('generate', () => {
 				listenAt: 'body',
 				type: 'keydown',
 				callback: () => 'closed',
+				capture: false,
 				activitySignal
 			},
 			{ listenerId: 'escape-close' }
@@ -365,7 +367,7 @@ describe('generate', () => {
 
 		expect(result.code).toContain('const makooTasks = [];');
 		expect(result.code).toContain(
-			'makooTasks.push(listen({"id":"escape-close","listenAt":"body","type":"keydown","callback":Manifest_0["listeners"]["escape-close"]["callback"],"activitySignal":Manifest_0["listeners"]["escape-close"]["activitySignal"]}));'
+			'makooTasks.push(listen({"id":"escape-close","listenAt":"body","type":"keydown","callback":Manifest_0["listeners"]["escape-close"]["callback"],"capture":false,"activitySignal":Manifest_0["listeners"]["escape-close"]["activitySignal"]}));'
 		);
 		expect(result.code).not.toContain('get: () => true');
 		expect(result.code).not.toContain('subscribe: () => () => {}');

--- a/packages/cli/test/resolve.test.ts
+++ b/packages/cli/test/resolve.test.ts
@@ -269,6 +269,7 @@ describe('resolve helpers', () => {
 				listenAt: 'body',
 				type: 'keydown',
 				callback,
+				capture: false,
 				match: ['https://example.com/*']
 			},
 			{
@@ -282,6 +283,7 @@ describe('resolve helpers', () => {
 			listenAt: 'body',
 			type: 'keydown',
 			callback,
+			capture: false,
 			enabled: true,
 			match: {
 				include: ['https://example.com/*']

--- a/packages/cli/test/validation.test.ts
+++ b/packages/cli/test/validation.test.ts
@@ -202,9 +202,29 @@ describe('InjectionModuleListenerSchema', () => {
 			listenAt: '#button',
 			type: 'click',
 			callback,
+			capture: true,
 			activitySignal
 		});
 		expect(result.success).toBe(true);
+	});
+
+	it('accepts false capture and rejects non-boolean capture values', () => {
+		expect(
+			InjectionModuleListenerSchema.safeParse({
+				listenAt: '#button',
+				type: 'click',
+				callback: () => undefined,
+				capture: false
+			}).success
+		).toBe(true);
+		expect(
+			InjectionModuleListenerSchema.safeParse({
+				listenAt: '#button',
+				type: 'click',
+				callback: () => undefined,
+				capture: 'true'
+			}).success
+		).toBe(false);
 	});
 
 	it('rejects missing callback', () => {
@@ -223,6 +243,7 @@ describe('InjectionListenerSchema', () => {
 			listenAt: 'body',
 			type: 'keydown',
 			callback: () => undefined,
+			capture: true,
 			activitySignal: () => ({ value: true }),
 			match: ['https://example.com/*'],
 			enabled: true

--- a/packages/core/README.CN.md
+++ b/packages/core/README.CN.md
@@ -171,11 +171,14 @@ type MakooListenerInput = {
 	listenAt: string;
 	type: string;
 	callback: EventListener;
+	capture?: boolean;
 	activitySignal?: () => ActivitySignalSource<boolean>;
 };
 ```
 
 `id` 省略时，运行时使用 `listener-${listenAt}-${type}` 作为任务 ID。
+`capture` 为 `true` 时会在 DOM 捕获阶段监听事件；默认保持浏览器行为，即 `false`，
+在冒泡阶段监听。listener 使用的 abort signal 仍由 Makoo 内部管理。
 
 ### Returns
 
@@ -188,6 +191,7 @@ const declaration = listen({
 	id: 'escape-close',
 	listenAt: 'body',
 	type: 'keydown',
+	capture: true,
 	callback: onEscape
 });
 ```
@@ -594,6 +598,7 @@ type MakooListenerDeclaration = {
 	event: string;
 	type: string;
 	callback: EventListener;
+	capture?: boolean;
 	activitySignal?: () => ActivitySignalSource<boolean>;
 };
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -169,11 +169,14 @@ type MakooListenerInput = {
 	listenAt: string;
 	type: string;
 	callback: EventListener;
+	capture?: boolean;
 	activitySignal?: () => ActivitySignalSource<boolean>;
 };
 ```
 
 When `id` is omitted, the runtime uses `listener-${listenAt}-${type}` as the task ID.
+`capture` selects the DOM capture phase when `true`; it defaults to the browser behavior of
+`false` (the bubbling phase). Makoo continues to manage the listener's abort signal internally.
 
 ### Returns
 
@@ -186,6 +189,7 @@ const declaration = listen({
 	id: 'escape-close',
 	listenAt: 'body',
 	type: 'keydown',
+	capture: true,
 	callback: onEscape
 });
 ```
@@ -590,6 +594,7 @@ type MakooListenerDeclaration = {
 	event: string;
 	type: string;
 	callback: EventListener;
+	capture?: boolean;
 	activitySignal?: () => ActivitySignalSource<boolean>;
 };
 

--- a/packages/core/src/Makoo/createMakoo.ts
+++ b/packages/core/src/Makoo/createMakoo.ts
@@ -73,6 +73,7 @@ export function listen(input: MakooListenerInput): MakooListenerDeclaration {
 		event: input.type,
 		type: input.type,
 		callback: input.callback,
+		...(typeof input.capture !== 'undefined' ? { capture: input.capture } : {}),
 		...(input.activitySignal ? { activitySignal: input.activitySignal } : {})
 	};
 }

--- a/packages/core/src/Makoo/types.ts
+++ b/packages/core/src/Makoo/types.ts
@@ -15,6 +15,7 @@ export type MakooListenerInput = {
 	listenAt: string;
 	type: string;
 	callback: EventListener;
+	capture?: boolean;
 	activitySignal?: TaskActivitySignal;
 };
 
@@ -25,6 +26,7 @@ export type MakooListenerDeclaration = {
 	event: string;
 	type: string;
 	callback: EventListener;
+	capture?: boolean;
 	activitySignal?: TaskActivitySignal;
 };
 

--- a/packages/core/src/Task/TaskRegister.ts
+++ b/packages/core/src/Task/TaskRegister.ts
@@ -27,6 +27,7 @@ export type ListenerDeclaration = {
 	listenAt: string;
 	event: string;
 	callback: EventListener;
+	capture?: boolean;
 	activitySignal?: TaskActivitySignal;
 };
 
@@ -34,7 +35,7 @@ export function registerListener(
 	runtime: MakooRuntimeState,
 	declaration: ListenerDeclaration
 ): ListenerRegisterResult {
-	const { id: explicitId, listenAt, event, callback, activitySignal } = declaration;
+	const { id: explicitId, listenAt, event, callback, capture, activitySignal } = declaration;
 	const id = explicitId ?? `listener-${listenAt}-${event}`;
 
 	runtime.emit(
@@ -80,6 +81,9 @@ export function registerListener(
 			event,
 			callback
 		};
+		if (typeof capture !== 'undefined') {
+			context.capture = capture;
+		}
 		if (activitySignal) {
 			context.activitySignal = activitySignal;
 		}
@@ -211,6 +215,10 @@ export function registerInjection<TArtifact>(
 				callback: options.on.callback
 			};
 			context.withEvent = true;
+
+			if (typeof options.on.capture !== 'undefined') {
+				listener.capture = options.on.capture;
+			}
 
 			if (options.on.activitySignal) {
 				listener.activitySignal = options.on.activitySignal;

--- a/packages/core/src/Task/TaskRunner.ts
+++ b/packages/core/src/Task/TaskRunner.ts
@@ -285,7 +285,8 @@ export function controlListener(
 				context.kind,
 				listener.listenAt,
 				listener.event,
-				listener.callback
+				listener.callback,
+				listener.capture
 			);
 
 			if (newController) {
@@ -364,12 +365,14 @@ function attachEvent(
 	kind: Task['kind'],
 	listenAt: string,
 	event: string,
-	callback: EventListener
+	callback: EventListener,
+	capture = false
 ): AbortController | null {
 	const element = document.querySelector(listenAt) as HTMLElement;
 	if (element) {
 		const controller = new AbortController();
 		element.addEventListener(event, callback, {
+			capture,
 			signal: controller.signal
 		});
 		runtime.logger.info(`Event "${event}" attached at "${listenAt}" (task: ${id})`);
@@ -382,6 +385,7 @@ function attachEvent(
 		(el) => {
 			if (proxyController.signal.aborted) return;
 			el.addEventListener(event, callback, {
+				capture,
 				signal: proxyController.signal
 			});
 			runtime.logger.info(`Event "${event}" attached at "${listenAt}" (task: ${id})`);

--- a/packages/core/src/Task/types.ts
+++ b/packages/core/src/Task/types.ts
@@ -51,6 +51,7 @@ export interface ListenerTask extends BaseTask {
 	listenAt: string;
 	event: string;
 	callback: EventListener;
+	capture?: boolean;
 	controller?: AbortController;
 	activitySignal?: TaskActivitySignal;
 
@@ -61,6 +62,7 @@ export type TaskListenerFeature = {
 	listenAt: string;
 	event: string;
 	callback: EventListener;
+	capture?: boolean;
 	controller?: AbortController;
 	activitySignal?: TaskActivitySignal;
 };

--- a/packages/core/test/MakooDeclaration.test.ts
+++ b/packages/core/test/MakooDeclaration.test.ts
@@ -71,6 +71,7 @@ describe('Makoo declarations', () => {
 			listenAt: '#escape',
 			type: 'keydown',
 			callback,
+			capture: true,
 			activitySignal
 		});
 
@@ -80,7 +81,23 @@ describe('Makoo declarations', () => {
 			event: 'keydown',
 			type: 'keydown',
 			callback,
+			capture: true,
 			activitySignal
+		});
+	});
+
+	it('should preserve an explicit false capture option', () => {
+		const callback = vi.fn();
+		const declaration = listen({
+			listenAt: '#escape',
+			type: 'keydown',
+			callback,
+			capture: false
+		});
+
+		expect(declaration).toMatchObject({
+			callback,
+			capture: false
 		});
 	});
 

--- a/packages/core/test/TaskRegister.test.ts
+++ b/packages/core/test/TaskRegister.test.ts
@@ -161,6 +161,7 @@ describe('TaskRegister', () => {
 					listenAt: '#btn',
 					type: 'click',
 					callback,
+					capture: true,
 					activitySignal
 				})
 			}
@@ -185,6 +186,7 @@ describe('TaskRegister', () => {
 				listenAt: '#btn',
 				event: 'click',
 				callback,
+				capture: true,
 				activitySignal
 			}
 		});
@@ -369,7 +371,12 @@ describe('TaskRegister', () => {
 
 	it('should register listener-only task', () => {
 		const callback = vi.fn();
-		const result = registerListener(runtime, { listenAt: '#btn', event: 'click', callback });
+		const result = registerListener(runtime, {
+			listenAt: '#btn',
+			event: 'click',
+			callback,
+			capture: false
+		});
 		const context = taskContext.get(result.taskId);
 
 		expect(result).toEqual({ taskId: 'listener-#btn-click', isSuccess: true });
@@ -380,6 +387,7 @@ describe('TaskRegister', () => {
 				listenAt: '#btn',
 				event: 'click',
 				callback,
+				capture: false,
 				withEvent: true,
 				timeout: 5000
 			})

--- a/packages/core/test/TaskRunner.test.ts
+++ b/packages/core/test/TaskRunner.test.ts
@@ -660,6 +660,55 @@ describe('TaskRunner', () => {
 		expect(callback).toHaveBeenCalledOnce();
 	});
 
+	it('should use capture when the listener target already exists', () => {
+		const btn = document.createElement('button');
+		btn.id = 'capture-listener-btn';
+		document.body.appendChild(btn);
+		const callback = vi.fn();
+		const addEventSpy = vi.spyOn(btn, 'addEventListener');
+		taskContext.set(
+			'capture-listener-task',
+			createListenerTask({
+				taskId: 'capture-listener-task',
+				withEvent: true,
+				listenAt: '#capture-listener-btn',
+				event: 'click',
+				callback,
+				capture: true
+			})
+		);
+
+		expect(controlListener(runtime, 'capture-listener-task', Action.OPEN)).toBe(true);
+		expect(addEventSpy).toHaveBeenCalledWith('click', callback, {
+			capture: true,
+			signal: expect.any(AbortSignal)
+		});
+	});
+
+	it('should default to the bubbling phase when capture is omitted', () => {
+		const btn = document.createElement('button');
+		btn.id = 'bubble-listener-btn';
+		document.body.appendChild(btn);
+		const callback = vi.fn();
+		const addEventSpy = vi.spyOn(btn, 'addEventListener');
+		taskContext.set(
+			'bubble-listener-task',
+			createListenerTask({
+				taskId: 'bubble-listener-task',
+				withEvent: true,
+				listenAt: '#bubble-listener-btn',
+				event: 'click',
+				callback
+			})
+		);
+
+		expect(controlListener(runtime, 'bubble-listener-task', Action.OPEN)).toBe(true);
+		expect(addEventSpy).toHaveBeenCalledWith('click', callback, {
+			capture: false,
+			signal: expect.any(AbortSignal)
+		});
+	});
+
 	it('should emit normalized listener open and close payloads', () => {
 		const observer = createObserverHub();
 		runtime = createRuntime(observer);
@@ -1058,8 +1107,11 @@ describe('TaskRunner', () => {
 	});
 
 	it('should use onDomReady fallback when listen target does not exist in OPEN', () => {
+		const delayedTarget = document.createElement('button');
+		const addEventSpy = vi.spyOn(delayedTarget, 'addEventListener');
+		const callback = vi.fn();
 		const readySpy = vi.spyOn(DOMWatcher, 'onDomReady').mockImplementation((_, cb) => {
-			const el = document.createElement('button');
+			const el = delayedTarget;
 			cb(el);
 			return () => {};
 		});
@@ -1070,13 +1122,18 @@ describe('TaskRunner', () => {
 				withEvent: true,
 				listenAt: '#non-existing-btn',
 				event: 'click',
-				callback: vi.fn()
+				callback,
+				capture: true
 			})
 		);
 
 		const result = controlListener(runtime, 'fallback-open-task', Action.OPEN);
 		expect(result).toBe(true);
 		expect(readySpy).toHaveBeenCalledOnce();
+		expect(addEventSpy).toHaveBeenCalledWith('click', callback, {
+			capture: true,
+			signal: expect.any(AbortSignal)
+		});
 		expect(taskContext.get<ListenerTask>('fallback-open-task')?.controller).toBeInstanceOf(
 			AbortController
 		);

--- a/packages/core/test/factory/TaskFactor.ts
+++ b/packages/core/test/factory/TaskFactor.ts
@@ -41,6 +41,7 @@ export type CreateListenerTaskInput = TaskBaseInput & {
 	listenAt?: string;
 	event?: string;
 	callback?: EventListener;
+	capture?: boolean;
 	controller?: AbortController;
 	activitySignal?: () => ActivitySignalSource<boolean>;
 };
@@ -87,6 +88,7 @@ export function createTask(input: CreateArtifactTaskInput | CreateListenerTaskIn
 		listenAt: input.listenAt ?? '#app',
 		event: input.event ?? 'click',
 		callback: input.callback ?? (() => undefined),
+		...(typeof input.capture !== 'undefined' ? { capture: input.capture } : {}),
 		...(input.controller ? { controller: input.controller } : {}),
 		...(input.activitySignal ? { activitySignal: input.activitySignal } : {})
 	};

--- a/packages/create-makoo/src/template/makooVersion.ts
+++ b/packages/create-makoo/src/template/makooVersion.ts
@@ -3,5 +3,5 @@ export const recommendedMakooVersions = {
 	cli: '^0.4.1',
 	vue: '^0.1.3',
 	react: '^0.1.3',
-	'create-makoo': '^0.1.7'
+	'create-makoo': '^0.1.8'
 } as const satisfies Record<string, string>;

--- a/packages/create-makoo/src/template/makooVersion.ts
+++ b/packages/create-makoo/src/template/makooVersion.ts
@@ -1,6 +1,6 @@
 export const recommendedMakooVersions = {
-	core: '^0.3.0',
-	cli: '^0.4.0',
+	core: '^0.3.1',
+	cli: '^0.4.1',
 	vue: '^0.1.3',
 	react: '^0.1.3',
 	'create-makoo': '^0.1.7'

--- a/skills/makoo-best-practices/SKILL.md
+++ b/skills/makoo-best-practices/SKILL.md
@@ -108,6 +108,23 @@ Use the top-level manifest for `injectionDefaults`, the injection collection, an
 
 When a top-level injection and a module-level manifest resolve to the same module id, Makoo merges their top-level fields. Explicit module fields win and missing module fields can come from the top-level entry. Treat `hooks` and `on` as whole top-level fields rather than expecting a deep merge inside either object.
 
+## Choose The Listener Event Phase
+
+Standalone listeners belong in the top-level manifest; component-owned listeners belong in an injection module's `on` field. Both forms support an optional `capture` boolean:
+
+```ts
+listeners: {
+	'escape-close': {
+		listenAt: 'body',
+		type: 'keydown',
+		capture: true,
+		callback: onEscape
+	}
+}
+```
+
+Use `capture: true` when the handler must run during the DOM capture phase. Omit it or set it to `false` for the normal bubbling phase. Keep explicit `false` values intact when transforming configuration or generated code.
+
 ## Put Component Logic In Framework Files
 
 Use the module entry component as the UI boundary:
@@ -236,6 +253,7 @@ Before finishing work in a Makoo-powered project, check:
 - Manifest top-level code has no application side effects or Node-only dependencies.
 - Hooks, callbacks, activity signals, and their imported helpers are browser-bundleable.
 - Standalone listeners live in the top-level manifest, not a module-level manifest.
+- Listener `capture` is chosen deliberately: `true` for capture, omitted/`false` for bubbling.
 - Module and top-level injection fields follow explicit-module-field precedence without assuming a deep merge.
 - Component logic lives in `app.tsx`, `app.jsx`, `app.vue`, or module-local framework files.
 - React/Vue mounting is handled by Makoo adapters.

--- a/skills/makoo-injection-workflow/SKILL.md
+++ b/skills/makoo-injection-workflow/SKILL.md
@@ -254,9 +254,23 @@ Standalone listener fields have these roles:
 - `listenAt`: selects the event target understood by the Makoo listener runtime.
 - `type`: provides the DOM event type.
 - `callback`: provides the event handler.
+- `capture`: optionally selects the DOM capture phase when `true`; omitted or `false` uses bubbling.
 - `activitySignal`: optionally controls whether the listener task is active.
 - `match`: limits registration by URL after the userscript has loaded.
 - `enabled`: removes a disabled listener from the generated runtime.
+
+Use the same `capture` field on an injection module's `on` listener when the component-owned event must run during capture:
+
+```ts
+on: {
+	listenAt: 'body',
+	type: 'click',
+	capture: true,
+	callback: onClick
+}
+```
+
+`capture: false` is meaningful and should be kept when explicitly configured; do not replace presence checks with a truthy check in generated code.
 
 Do not add `injectAt`, `alive`, `scope`, or `timeout` to standalone listeners. Those fields belong to component injection tasks.
 
@@ -405,5 +419,6 @@ Before finishing injection work, check:
 - `timeout` reflects when the target node appears and is not hiding an incorrect selector.
 - Module and top-level injection configs follow shallow top-level field precedence; `hooks` and `on` each have one authoritative source.
 - Standalone listeners are declared in the top-level manifest and do not use injection-only fields.
+- Listener `capture` is optional, defaults to bubbling when omitted, and is preserved when explicitly set to `false`.
 - Hooks, callbacks, activity signals, and their helper chains use static relative imports and remain browser-bundleable.
 - If the project mixes React and Vue, dependencies, Vite plugins, and userscript external globals support the selected frameworks.


### PR DESCRIPTION
This pull request introduces support for a `capture` option on event listeners throughout the Makoo CLI and core packages. The `capture` option allows listeners to be registered during the DOM capture phase rather than the default bubbling phase. The change is reflected in the code, configuration types, runtime logic, documentation, and tests, ensuring that both the feature and its usage are well-documented and validated.

**Feature: DOM event listener capture phase support**

* Added an optional `capture` property to listener configuration types (`InjectionModuleListenerConfig`, `MakooListenerInput`, etc.) across the codebase, allowing listeners to be registered in the DOM capture phase when set to `true`. [[1]](diffhunk://#diff-f179fc87563e5017a3ff3d9847279c8473fed0dcdbce511edbbc934f6dc46d97R130) [[2]](diffhunk://#diff-7f1033a34b8b81f9a390195afd0b8eabe38061f7d455497c35de6379f2f7fafdR18) [[3]](diffhunk://#diff-7f1033a34b8b81f9a390195afd0b8eabe38061f7d455497c35de6379f2f7fafdR29) [[4]](diffhunk://#diff-7d493d55bb7f56667eb09a266bece7128b79d9a3916a3db9e7b2d6a958834400R30-R38) [[5]](diffhunk://#diff-cb773e2ad95f2ca305b22495f4be254c76612724a26012c5bb8eb750b263994eR174-R181) [[6]](diffhunk://#diff-af0c08d6f291aa75c55d4ad3ec19fd4b728edcf43a39c80d566f661b3b311c44R172-R179) [[7]](diffhunk://#diff-7d2cfefc086e636ecf9e04625f2a3c98d558c6df3b9d59ed8ad6e99f204d4f1fR46) [[8]](diffhunk://#diff-15986190ef9581ab59bcd5483b2c09e7fd0bd439d6f6cddbc94b0b1de094ee51R309) [[9]](diffhunk://#diff-443d6d239c8846c987e28305ca556ac675ce9bd1697547814a793aba1d7722bbR309)
* Updated listener registration and runtime logic to pass the `capture` option through to actual event registration, ensuring correct behavior at runtime. [[1]](diffhunk://#diff-7d493d55bb7f56667eb09a266bece7128b79d9a3916a3db9e7b2d6a958834400R84-R86) [[2]](diffhunk://#diff-7d493d55bb7f56667eb09a266bece7128b79d9a3916a3db9e7b2d6a958834400R219-R222) [[3]](diffhunk://#diff-ad2167dee57ff95b7464220b3c9abfd3b0a66b8bf9dc7fb2e401ea414dc31d65L288-R289) [[4]](diffhunk://#diff-4340d3330a976a67a2275b6a2ea9f930fb851979aa3ac5d65f43f61e9bf6f8b8R76)

**Documentation updates**

* Updated all relevant documentation and code examples in both English and Chinese (`README.md`, `README.CN.md`, and package docs) to describe the new `capture` option, its default value, and usage. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L242-R244) [[2]](diffhunk://#diff-a1785f19d824b74f0d78693e120cd59fa15d6c59d277adca86b4cfc09c186497L239-R240) [[3]](diffhunk://#diff-cb773e2ad95f2ca305b22495f4be254c76612724a26012c5bb8eb750b263994eR174-R181) [[4]](diffhunk://#diff-cb773e2ad95f2ca305b22495f4be254c76612724a26012c5bb8eb750b263994eR194) [[5]](diffhunk://#diff-af0c08d6f291aa75c55d4ad3ec19fd4b728edcf43a39c80d566f661b3b311c44R172-R179) [[6]](diffhunk://#diff-af0c08d6f291aa75c55d4ad3ec19fd4b728edcf43a39c80d566f661b3b311c44R192) [[7]](diffhunk://#diff-443d6d239c8846c987e28305ca556ac675ce9bd1697547814a793aba1d7722bbR320-R322) [[8]](diffhunk://#diff-15986190ef9581ab59bcd5483b2c09e7fd0bd439d6f6cddbc94b0b1de094ee51R320-R322)

**Code generation and validation**

* Updated code generation logic to include the `capture` property when present, and updated schema validation to accept only boolean values for `capture`. [[1]](diffhunk://#diff-044d9e7f11ad54c346442742edf78390ee558a5bcf7ff2222c8aec9de5c7b761R70-R72) [[2]](diffhunk://#diff-2254a0fb31c800ee8c86c67df7696da5da21e2ce76d40912bcc3404659185048R23-R25) [[3]](diffhunk://#diff-7d2cfefc086e636ecf9e04625f2a3c98d558c6df3b9d59ed8ad6e99f204d4f1fR46) [[4]](diffhunk://#diff-23c5a5b4995c079b2dcd3907aa5789b17220afccb3dced8f095e813636ed7a4bR205-R229)

**Tests**

* Added and updated tests to cover the `capture` property, including validation, code generation, and runtime behavior. [[1]](diffhunk://#diff-d88337d8811e814b34d0a77b07215820cf6a5802c7f6cecd5bcceb34dc11f08bR46) [[2]](diffhunk://#diff-d88337d8811e814b34d0a77b07215820cf6a5802c7f6cecd5bcceb34dc11f08bL123-R124) [[3]](diffhunk://#diff-d88337d8811e814b34d0a77b07215820cf6a5802c7f6cecd5bcceb34dc11f08bR333) [[4]](diffhunk://#diff-d88337d8811e814b34d0a77b07215820cf6a5802c7f6cecd5bcceb34dc11f08bL368-R370) [[5]](diffhunk://#diff-b9ddfbf095e20a31f7513f2cc97d9684c20c82ced7e5d500c47ea43dd0c0d1d4R272) [[6]](diffhunk://#diff-b9ddfbf095e20a31f7513f2cc97d9684c20c82ced7e5d500c47ea43dd0c0d1d4R286) [[7]](diffhunk://#diff-23c5a5b4995c079b2dcd3907aa5789b17220afccb3dced8f095e813636ed7a4bR205-R229) [[8]](diffhunk://#diff-23c5a5b4995c079b2dcd3907aa5789b17220afccb3dced8f095e813636ed7a4bR246)

**Example and manifest updates**

* Updated code examples and manifest snippets to demonstrate how to use the `capture` option in listener definitions. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R232) [[2]](diffhunk://#diff-a1785f19d824b74f0d78693e120cd59fa15d6c59d277adca86b4cfc09c186497R230) [[3]](diffhunk://#diff-443d6d239c8846c987e28305ca556ac675ce9bd1697547814a793aba1d7722bbR213) [[4]](diffhunk://#diff-443d6d239c8846c987e28305ca556ac675ce9bd1697547814a793aba1d7722bbR249) [[5]](diffhunk://#diff-15986190ef9581ab59bcd5483b2c09e7fd0bd439d6f6cddbc94b0b1de094ee51R213) [[6]](diffhunk://#diff-15986190ef9581ab59bcd5483b2c09e7fd0bd439d6f6cddbc94b0b1de094ee51R249) [[7]](diffhunk://#diff-cb773e2ad95f2ca305b22495f4be254c76612724a26012c5bb8eb750b263994eR194) [[8]](diffhunk://#diff-af0c08d6f291aa75c55d4ad3ec19fd4b728edcf43a39c80d566f661b3b311c44R192)

These changes make the event listener system more flexible by supporting both capture and bubbling phases, and ensure that the feature is robustly documented and tested.